### PR TITLE
Release branch for 0.2.0

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.1.1
+ * Version: 0.2.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,8 @@
-*** Woo Blaze Changelog ***
+*** Blaze for WooCommerce Changelog ***
+
+= 0.2.0 - 2024-06-20 =
+* Update - Change plugin slug from woo-blaze to blaze-ads
+* Update - Update the version of the packages: automattic/jetpack-blaze, automattic/jetpack-sync
 
 = 0.1.1 - 2024-05-08 =
 * Fix - Fixes the marketing channel setup check

--- a/changelog/feature-update-jetpack-blaze
+++ b/changelog/feature-update-jetpack-blaze
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update the version of the packages: automattic/jetpack-blaze, automattic/jetpack-sync

--- a/changelog/update-slug
+++ b/changelog/update-slug
@@ -1,4 +1,0 @@
-Significance: major
-Type: update
-
-Change plugin slug from woo-blaze to blaze-ads

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Woo Blaze",
 	"license": "GPL-3.0-or-later",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Woo Blaze",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 0.1.1
+Stable tag: 0.2.0
 
 One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
 
@@ -28,6 +28,10 @@ Blaze is an exclusive ad platform that allows you to grow your audience by promo
 Install and activate the WooCommerce, Jetpack and Woo Blaze plugins, if you haven't already done so, then go to "Marketing->Blaze for WooCommerce" in the WordPress admin menu and follow the instructions there.
 
 == Changelog ==
+
+= 0.2.0 - 2024-06-20 =
+* Update - Change plugin slug from woo-blaze to blaze-ads
+* Update - Update the version of the packages: automattic/jetpack-blaze, automattic/jetpack-sync
 
 = 0.1.1 - 2024-05-08 =
 * Fix - Fixes the marketing channel setup check


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [ ] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Update - Change plugin slug from woo-blaze to blaze-ads
* Update - Update the version of the packages: automattic/jetpack-blaze, automattic/jetpack-sync
```