### PR TITLE
Fixes the setup script

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -22,7 +22,7 @@ cli()
 	if [ -t 1 ] ; then
 		INTERACTIVE='-it'
 	fi
-	redirect_output docker run $INTERACTIVE --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
+	redirect_output docker run $INTERACTIVE --env-file default.env --rm --user www-data --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
 }
 
 set +e

--- a/changelog/fix-setup-script
+++ b/changelog/fix-setup-script
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes the setup script to use a different cli user
+
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,3 +56,17 @@ services:
 ```
 I used port `9003` as an example.
 To apply the change, restart your containers using `pnpm docker:down && pnpm docker:up`
+
+## Troubleshooting
+
+These are some of the errors we have had, and we want to document them in case they resurface over time.
+
+### docker: Error response from daemon: unable to find user ...
+
+Our setup script (`blaze-ads/bin/docker-setup.sh`) uses the wordpress:cli tool to configure the development site.
+In the past, we used the user `xfs` to run the `wp cli` script, but something changed in the cli docker container, and had to update our script to start using `www-data` instead.
+
+The main problem was probably because of WP-CLI changing its base system to Alpine, and that system uses a different user.
+
+If this error happens in the future, check this page: https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
+There may be additional information there. As an alternative, you can remove the user from the wp client call inside the `docker-setup.sh` script. 


### PR DESCRIPTION
### What and why? 🤔

We are getting errors when we first install the development environment about a missing user:
```
docker: Error response from daemon: unable to find user xfs: no matching entries in passwd file
```

After some digging and testing, it appears that the base docker container changed to Alpine, and we need to use a different user for the cli. Check https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user

I changed the user we used for cli in the setup script and added a Troubleshooting section to the readme file to document this in case it happens again.

### Testing Steps ✍️

Code review should be enough. 

If you want a full test, just checkout this branch and start a clean environment (you will need to remove the untracked files inside the `blaze-ads/docker` folder.

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
