### PR TITLE
Adds the plugin version to the dashboard initial config data

### DIFF
--- a/changelog/add-plugin-version-to-dashboard-config
+++ b/changelog/add-plugin-version-to-dashboard-config
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds the plugin version as one of the props that we send to the dashboard app

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -114,6 +114,17 @@ class Blaze_Dashboard {
 			$data['jetpack_error_message'] = $jetpack_error_message;
 		}
 
+		// Add additional options to the site's information.
+		if ( ! empty( $data['initial_state'] ) && ! empty( $data['initial_state']['sites'] ) && ! empty( $data['initial_state']['sites']['items'] ) ) {
+			foreach ( $data['initial_state']['sites']['items'] as $key => $site ) {
+				$options = $site['options'] ?? array();
+
+				$options['blaze_ads_version'] = WOOBLAZE_VERSION_NUMBER;
+
+				$data['initial_state']['sites']['items'][ $key ]['options'] = $options;
+			}
+		}
+
 		return $data;
 	}
 


### PR DESCRIPTION
See: 1807-gh-Tumblr/a8c-dsp

Related PRs: DSP (2421-gh-Tumblr/a8c-dsp) & [Calypso](https://github.com/Automattic/wp-calypso/pull/93224)

### What and why? 🤔

When the plugin works in standalone mode (jetpack is not installed in the site), it uses the old version of the create campaign endpoints. 

This happens because in standalone mode, we don't have the Jetpack version, and the DSP will tell the widget to disable the new campaign endpoints (they are only enabled for Jetpack >=13.2).

In this PR, I am sending the plugin version as an additional parameter, and I plan to change the DSP to start checking for it along with the jetpack version.

### Testing Steps ✍️

* Checkout this branch and start your local environment
* Go to Marketing->Blaze for WooCommerce
* Open the browser console, and check the value of the variable `window.configData`
* You should see the new version inside of the site option (json path: `initial_state.sites.items.ID.options. blaze_ads_version `)


### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
