### PR TITLE
Release branch for 0.4.0

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.3.2
+ * Version: 0.4.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 *** Blaze Ads Changelog ***
 
+2024-08-15 - version 0.4.0
+* Add - Adds additional flags to the dashboard config initial data
+* Add - Adds the plugin version as one of the props that we send to the dashboard app
+* Update - Extend plugin to support sites without woo
+* Update - Rename Blaze for WooCommerce to Blaze Ads
+* Update - update jetpack connect flow and idc for non-woo sites
+
 2024-07-29 - version 0.3.2
 * Dev - Fix changelog entries missing when generating readme.txt
 * Dev - update license

--- a/changelog/add-new-flags-to-dashboard-config-data
+++ b/changelog/add-new-flags-to-dashboard-config-data
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adds additional flags to the dashboard config initial data

--- a/changelog/add-plugin-version-to-dashboard-config
+++ b/changelog/add-plugin-version-to-dashboard-config
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adds the plugin version as one of the props that we send to the dashboard app

--- a/changelog/chore-jetpack-connect-non-woo
+++ b/changelog/chore-jetpack-connect-non-woo
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-update jetpack connect flow and idc for non-woo sites

--- a/changelog/chore-remove-woo-restrictions
+++ b/changelog/chore-remove-woo-restrictions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Extend plugin to support sites without woo

--- a/changelog/chore-update-name
+++ b/changelog/chore-update-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Rename Blaze for WooCommerce to Blaze Ads

--- a/changelog/fix-setup-script
+++ b/changelog/fix-setup-script
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fixes the setup script to use a different cli user
-
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 0.3.2
+Stable tag: 0.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -36,6 +36,13 @@ Install Blaze Ads and Jetpack plugin (optional), then go to "Tools -> Advertisin
 Install and activate the WooCommerce, Blaze Ads plugins and Jetpack (optional), if you haven't already done so, then go to "Marketing->Blaze Ads" in the WordPress admin menu and follow the instructions there.
 
 == Changelog ==
+
+= 0.4.0 - 2024-08-15 =
+* Add - Adds additional flags to the dashboard config initial data
+* Add - Adds the plugin version as one of the props that we send to the dashboard app
+* Update - Extend plugin to support sites without woo
+* Update - Rename Blaze for WooCommerce to Blaze Ads
+* Update - update jetpack connect flow and idc for non-woo sites
 
 = 0.3.2 - 2024-07-29 =
 * Dev - Fix changelog entries missing when generating readme.txt


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [x] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Add - Adds additional flags to the dashboard config initial data
* Add - Adds the plugin version as one of the props that we send to the dashboard app
* Update - Extend plugin to support sites without woo
* Update - Rename Blaze for WooCommerce to Blaze Ads
* Update - update jetpack connect flow and idc for non-woo sites
```