### PR TITLE
Fixes a problem with plugin dir in the marketing channel

### DIFF
--- a/changelog/fix-assets-plugin-dir
+++ b/changelog/fix-assets-plugin-dir
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes a problem with assets dir after merging rename refactor
+
+

--- a/includes/class-blaze-marketing-channel.php
+++ b/includes/class-blaze-marketing-channel.php
@@ -105,7 +105,7 @@ class Blaze_Marketing_Channel implements MarketingChannelInterface {
 	 * @return string
 	 */
 	public function get_icon_url(): string {
-		return plugins_url( 'assets/images/blaze-flame-woo.svg', WOOBLAZE_PLUGIN_FILE );
+		return plugins_url( 'assets/images/blaze-flame-woo.svg', BLAZEADS_PLUGIN_FILE );
 	}
 
 	/**


### PR DESCRIPTION
### What and why? 🤔

This PR fixes an error that we are getting about a missing variable. The problem was introduced after merging the refactor rename PR.

It changes the assets variable to use the correct one: `BLAZEADS_PLUGIN_FILE`

### Testing Steps ✍️

Code review will be enought.

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
