### PR TITLE
Improves the handling of the DSP API responses

### DIFF
--- a/changelog/update-improves-request-dsp-utility
+++ b/changelog/update-improves-request-dsp-utility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improves the handling of the DSP API responses

--- a/includes/class-blaze-ads.php
+++ b/includes/class-blaze-ads.php
@@ -20,9 +20,9 @@ class Blaze_Ads {
 	/**
 	 * Cache for plugin headers to avoid multiple calls to get_file_data
 	 *
-	 * @var array
+	 * @var ?array
 	 */
-	private static $plugin_headers = null;
+	private static ?array $plugin_headers = null;
 
 	/**
 	 * Static-only class.
@@ -59,7 +59,6 @@ class Blaze_Ads {
 		}
 	}
 
-
 	/**
 	 * Determines if criteria is met to enable Blaze Ads dashboard.
 	 *
@@ -77,7 +76,6 @@ class Blaze_Ads {
 	public static function display_admin_error( string $message ) {
 		self::display_admin_notice( $message, 'notice-error' );
 	}
-
 
 	/**
 	 * Prints the given message in an "admin notice" wrapper with provided classes.
@@ -103,7 +101,6 @@ class Blaze_Ads {
 		</div>
 		<?php
 	}
-
 
 	/**
 	 * Get plugin headers and cache the result to avoid reopening the file.

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -50,7 +50,7 @@ class Blaze_Dashboard {
 	 *
 	 * @return bool
 	 */
-	public function can_display_marketing_menu() {
+	public function can_display_marketing_menu(): bool {
 		return Blaze_Dependency_Service::is_woo_core_active();
 	}
 
@@ -59,7 +59,7 @@ class Blaze_Dashboard {
 	 *
 	 * @return bool
 	 */
-	public function should_enable_jetpack_blaze_menu() {
+	public function should_enable_jetpack_blaze_menu(): bool {
 		return $this->can_display_marketing_menu();
 	}
 
@@ -200,14 +200,14 @@ class Blaze_Dashboard {
 	 * In reality this is just to trigger a page reload that re-reruns the onboarding logic and this could have been a window.reload on client
 	 * this method simply makes sure the server controls the url that handles the connect redirect for easy change without needing to update the client.
 	 *
-	 * @param string $wcblaze_connect_from Optional. A page ID representing where the user should be returned to after connecting. Default is '1' - redirects back to the overview page.
+	 * @param string $blazeads_connect_from Optional. A page ID representing where the user should be returned to after connecting. Default is '1' - redirects back to the overview page.
 	 *
 	 * @return string Jetpack connect url.
 	 */
-	public function get_connect_url( $wcblaze_connect_from = '1' ): string {
+	public function get_connect_url( string $blazeads_connect_from = '1' ): string {
 		$admin_page = Blaze_Dependency_Service::is_woo_core_active() ? 'admin.php?page=wc-blaze' : 'tools.php?page=wc-blaze';
 		$url        = add_query_arg(
-			array( 'blaze-ads-connect' => $wcblaze_connect_from ),
+			array( 'blaze-ads-connect' => $blazeads_connect_from ),
 			admin_url( $admin_page )
 		);
 

--- a/includes/class-jetpack-connect-handler.php
+++ b/includes/class-jetpack-connect-handler.php
@@ -26,17 +26,13 @@ class Jetpack_Connect_Handler {
 	 */
 	private $connection_manager;
 
-
-
 	/**
 	 * Constructor
-	 * Setup the connection manager.
+	 * Sets up the connection manager.
 	 */
 	public function __construct() {
 		$this->connection_manager = new Manager( 'blaze-ads' );
 	}
-
-
 
 	/**
 	 * Handle onboarding flow.
@@ -47,9 +43,8 @@ class Jetpack_Connect_Handler {
 		}
 
 		if ( isset( $_GET['blaze-ads-connect'] ) && check_admin_referer( 'blaze-ads-connect' ) ) {
-				$is_connected = false;
-			if ( ! $is_connected ) {
-				$this->redirect_to_onboarding_flow_page();
+			if ( ! $this->is_connected() ) {
+				$this->redirect_to_onboarding_flow_page( 'blaze-ads-connect-page' );
 			}
 		}
 	}
@@ -62,9 +57,7 @@ class Jetpack_Connect_Handler {
 	 *
 	 * @return void
 	 */
-	private function redirect_to_onboarding_flow_page( string $source = 'blaze-ads-connect-page' ) {
-		$site_url = wp_parse_url( get_site_url(), PHP_URL_HOST );
-
+	private function redirect_to_onboarding_flow_page( string $source ) {
 		$admin_page   = Blaze_Dependency_Service::is_woo_core_active() ? 'admin.php?page=wc-blaze' : 'tools.php?page=wc-blaze';
 		$redirect_url = add_query_arg(
 			array( 'source' => $source ),
@@ -86,9 +79,9 @@ class Jetpack_Connect_Handler {
 	 * Utility function to immediately redirect to the dashboard connect page.
 	 * Note that this function immediately ends the execution.
 	 *
-	 * @param string $error_message Optional error message to show in a notice.
+	 * @param string|null $error_message Optional error message to show in a notice.
 	 */
-	public function redirect_to_connect_home_page( $error_message = null ) {
+	public function redirect_to_connect_home_page( string $error_message = null ) {
 		if ( isset( $error_message ) ) {
 			set_transient( self::ERROR_MESSAGE_TRANSIENT, $error_message, 30 );
 		}
@@ -105,7 +98,7 @@ class Jetpack_Connect_Handler {
 	 *
 	 * @return bool true if Jetpack connection has access token.
 	 */
-	public function is_connected() {
+	public function is_connected(): bool {
 		return $this->connection_manager->is_connected() && $this->connection_manager->has_connected_owner();
 	}
 
@@ -117,12 +110,12 @@ class Jetpack_Connect_Handler {
 	 *
 	 * @throws API_Exception - Exception thrown on failure.
 	 */
-	public function start_connection( $redirect ) {
+	public function start_connection( string $redirect ) {
 		// Register the site to wp.com.
 		if ( ! $this->connection_manager->is_connected() ) {
 			$result = $this->connection_manager->try_registration();
 			if ( is_wp_error( $result ) ) {
-				throw new API_Exception( $result->get_error_message(), 'wcblaze_jetpack_register_site_failed', 500 );
+				throw new API_Exception( $result->get_error_message(), 'blazeads_jetpack_register_site_failed', 500 );
 			}
 		}
 

--- a/includes/exceptions/class-api-exception.php
+++ b/includes/exceptions/class-api-exception.php
@@ -18,21 +18,21 @@ class API_Exception extends Base_Exception {
 	 *
 	 * @var int
 	 */
-	private $http_code = 0;
+	private int $http_code = 0;
 
 	/**
 	 * Error type attribute from the server.
 	 *
-	 * @var string
+	 * @var ?string
 	 */
-	private $error_type = null;
+	private ?string $error_type = null;
 
 	/**
 	 * Decline code if it is a card error.
 	 *
-	 * @var string
+	 * @var ?string
 	 */
-	private $decline_code = null;
+	private ?string $decline_code = null;
 
 	/**
 	 * Constructor
@@ -58,7 +58,7 @@ class API_Exception extends Base_Exception {
 	 *
 	 * @return int HTTP code, for example 404.
 	 */
-	public function get_http_code() {
+	public function get_http_code(): int {
 		return $this->http_code;
 	}
 
@@ -67,7 +67,7 @@ class API_Exception extends Base_Exception {
 	 *
 	 * @return string|null Error type, for example 'api_error' or 'card_error'.
 	 */
-	public function get_error_type() {
+	public function get_error_type(): ?string {
 		return $this->error_type;
 	}
 
@@ -76,7 +76,7 @@ class API_Exception extends Base_Exception {
 	 *
 	 * @return string|null Decline code, for example 'expired_card' or 'insufficient_funds'.
 	 */
-	public function get_decline_code() {
+	public function get_decline_code(): ?string {
 		return $this->decline_code;
 	}
 }

--- a/includes/exceptions/class-base-exception.php
+++ b/includes/exceptions/class-base-exception.php
@@ -15,13 +15,13 @@ defined( 'ABSPATH' ) || exit;
  * Abstract class for extension exceptions, where we allow to inject
  * human-friendly error codes, e.g. 'order_not_found'.
  */
-abstract class Base_Exception extends Exception {
+class Base_Exception extends Exception {
 	/**
 	 * String error code, for example 'order_not_found'.
 	 *
 	 * @var string
 	 */
-	private $error_code;
+	private string $error_code;
 
 	/**
 	 * Constructor, including the usual $message, $code, and $previous,
@@ -43,7 +43,7 @@ abstract class Base_Exception extends Exception {
 	 *
 	 * @return string Error code, for example 'order_not_found'.
 	 */
-	public function get_error_code() {
+	public function get_error_code(): string {
 		return $this->error_code;
 	}
 }


### PR DESCRIPTION
### What and why? 🤔

This PR standardizes the documentation of our variables/methods and improves the handling of DSP API response.

The DSP request utility method was missing a check for WP Errors. I included that and also added the status and body to the result. That will allow us to handle different situations in the future.

### Testing Steps ✍️

Its easier to test this by using a sandbox (you will need to generate DSP errors to fully test this).

To sandbox your plugin, you need to create a `hacks.php` file inside the `wp-content/mu-plugins` folder with this content:
```
<?php
define( 'JETPACK__SANDBOX_DOMAIN', '{your sandbox}.wordpress.com' );
```

After that:
* Install this plugin alongside with WooCommerce
* Navigate to Marketing->Overview
* Verify that you correctly see the Blaze Ads Channel
* Now, point the sandbox to your local DSP server, and force an error in the endpoint `/search/campaigns/site/{siteId}`
* Refresh the page, and you should still see the overview page. (You won't have any campaigns on the list)
* Now, change the status of one of your campaigns to active (it must belongs to this site) and remove the error we added in the search endpoint
* Refresh the page and verify that you see the active campaign on the list
![Screenshot 2024-09-18 at 4 21 55 PM](https://github.com/user-attachments/assets/06a197b4-5d5a-4397-9bd2-54aff5928b7c)


### Review checklist
- [ ] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
