### PR TITLE
Fixes how we extract the changelog for the release notes

### DIFF
--- a/.github/workflows/release-generate.yml
+++ b/.github/workflows/release-generate.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Get the last changelog in changelog.txt"
         id: get_changelog
         run: |
-          CHANGELOG=$(awk '/^= / { if (p) { exit }; p=1; next } p && NF' changelog.txt)
+          CHANGELOG=$(awk '/^[0-9]{4}-[0-9]{2}-[0-9]{2}/ { if (p) { exit }; p=1; next } p && NF' changelog.txt)
           CHANGELOG="${CHANGELOG//$'\n'/\\n}"  
           echo "CHANGELOG=$CHANGELOG" >> $GITHUB_OUTPUT
 

--- a/changelog/fix-release-note-changelog
+++ b/changelog/fix-release-note-changelog
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fixes the changelog we extract for the release notes
+
+


### PR DESCRIPTION
### What and why? 🤔

There is a bug in how we collect the changelog for the release notes, and they appear as empty. The main problem is that we changed the changelog format some time ago and only fixed the regex in the `process-changelog` GitHub` action, but we missed changing it in the generate release workflow.

![Screenshot 2024-09-23 at 4 34 14 PM](https://github.com/user-attachments/assets/eb0e98a9-8974-4f5e-8e0a-c79bf9fd013a)

I will try to manually update the previous release notes to include the changelog in them, but this will probably gets fixed for future releases.

### Testing Steps ✍️

* Execute the affected command in a unix-based console (linux, mac, etc).
* Verify that you see the last changelog entry
```
$  awk '/^[0-9]{4}-[0-9]{2}-[0-9]{2}/ { if (p) { exit }; p=1; next } p && NF' changelog.txt
* Dev - fix concerns reported by running Plugin Check (PCP)
```

Also, we already are using this command in the repo in [here](https://github.com/Automattic/blaze-ads/blob/2f22b4a617a4d266dce576d897d85e2cf0da5cad/.github/actions/process-changelog/action.yml#L70), you can compare against that line.

### Review checklist
- [ ] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
