### PR TITLE
Adds unit testing to the marketing channel implementation

### DIFF
--- a/changelog/add-marketing-channel-unit-tests
+++ b/changelog/add-marketing-channel-unit-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Adds unit testing to the Marketing channel implementation
+
+

--- a/includes/class-blaze-marketing-channel.php
+++ b/includes/class-blaze-marketing-channel.php
@@ -36,6 +36,11 @@ class Blaze_Marketing_Channel implements MarketingChannelInterface {
 	 * MarketingChannelRegistrar constructor.
 	 */
 	public function __construct() {
+		$this->campaign_types = array();
+
+		if ( $this->can_register_marketing_channel() ) {
+			$this->campaign_types = $this->generate_campaign_types();
+		}
 	}
 
 	/**
@@ -48,9 +53,8 @@ class Blaze_Marketing_Channel implements MarketingChannelInterface {
 			return;
 		}
 
-		$this->campaign_types = $this->generate_campaign_types();
-		$wc_container         = $GLOBALS['wc_container'];
-		$marketing_channels   = $wc_container->get( MarketingChannels::class );
+		$wc_container       = $GLOBALS['wc_container'];
+		$marketing_channels = $wc_container->get( MarketingChannels::class );
 		$marketing_channels->register( $this );
 	}
 
@@ -61,7 +65,6 @@ class Blaze_Marketing_Channel implements MarketingChannelInterface {
 	 * @return bool
 	 */
 	public function can_register_marketing_channel(): bool {
-
 		// Check if the Multichannel Marketing plugin is active.
 		if ( ! defined( 'WC_MCM_EXISTS' ) ) {
 			return false;
@@ -134,7 +137,7 @@ class Blaze_Marketing_Channel implements MarketingChannelInterface {
 	 * @return string
 	 */
 	public function get_product_listings_status(): string {
-		return self::PRODUCT_LISTINGS_NOT_APPLICABLE;
+		return MarketingChannelInterface::PRODUCT_LISTINGS_NOT_APPLICABLE;
 	}
 
 	/**

--- a/tests/php/blaze-marketing-channel-test.php
+++ b/tests/php/blaze-marketing-channel-test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Class Blaze_Marketing_Channel_Test
+ *
+ * @package BlazeAds\Tests
+ */
+
+namespace BlazeAds\Tests;
+
+use BlazeAds\Tests\Framework\BA_Unit_Test_Case;
+use BlazeAds\Blaze_Marketing_Channel;
+use Automattic\WooCommerce\Admin\Marketing\MarketingCampaignType;
+
+/**
+ * Blaze Marketing Channel Test.
+ *
+ * Tests the Blaze_Marketing_Channel class.
+ */
+class Blaze_Marketing_Channel_Test extends BA_Unit_Test_Case {
+
+	/** @var Blaze_Marketing_Channel $channel */
+	protected Blaze_Marketing_Channel $channel;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->channel = new Blaze_Marketing_Channel();
+	}
+
+	/**
+	 * Ensure the get_slug method returns information
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_slug
+	 */
+	public function test_get_slug_is_not_empty() {
+		$this->assertNotEmpty( $this->channel->get_slug() );
+	}
+
+	/**
+	 * Ensure the get_name method returns information
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_name
+	 */
+	public function test_get_name_is_not_empty() {
+		$this->assertNotEmpty( $this->channel->get_name() );
+	}
+
+	/**
+	 * Ensure the get_description method returns information
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_description
+	 */
+	public function test_get_description_is_not_empty() {
+		$this->assertNotEmpty( $this->channel->get_description() );
+	}
+
+	/**
+	 * Ensure the get_description method returns information
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_product_listings_status
+	 */
+	public function test_get_product_listings_status_is_not_empty() {
+		$this->assertNotEmpty( $this->channel->get_product_listings_status() );
+	}
+
+	/**
+	 * Ensure the get_description method returns information
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_product_listings_status
+	 */
+	public function test_get_errors_count_is_valid() {
+		$this->assertEquals( 0, $this->channel->get_errors_count() );
+	}
+
+	/**
+	 * Ensure we return a correct list of supported campaigns
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_supported_campaign_types
+	 */
+	public function test_get_supported_campaign_types_returns_ads_campaign() {
+		$this->assertCount( 1, $this->channel->get_supported_campaign_types() );
+		$this->assertContainsOnlyInstancesOf(
+			MarketingCampaignType::class,
+			$this->channel->get_supported_campaign_types()
+		);
+		$this->assertArrayHasKey( 'woo-blaze', $this->channel->get_supported_campaign_types() );
+		$this->assertEquals( 'woo-blaze', $this->channel->get_supported_campaign_types()['woo-blaze']->get_id() );
+	}
+
+	/**
+	 * Ensure we return a valid icon url
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_icon_url
+	 */
+	public function test_get_icon_url_is_valid() {
+		$this->assertNotEmpty( $this->channel->get_icon_url() );
+		$this->assertNotFalse( filter_var( $this->channel->get_icon_url(), FILTER_VALIDATE_URL ) );
+	}
+
+	/**
+	 * Ensure we return a valid setup url
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_setup_url
+	 */
+	public function test_get_setup_url_is_valid() {
+		$this->assertNotEmpty( $this->channel->get_setup_url() );
+		$this->assertNotFalse( filter_var( $this->channel->get_setup_url(), FILTER_VALIDATE_URL ) );
+	}
+
+	/**
+	 * Ensure we return a valid campaign list
+	 * TODO: We need to refactor the code to be able to correctly mock DSP calls. Currently, its only testing that we don't get an error
+	 *
+	 * @covers BlazeAds\Blaze_Marketing_Channel::get_setup_url
+	 */
+	public function test_get_campaigns_returns_array() {
+		$campaigns = $this->channel->get_campaigns();
+		$this->assertIsArray( $campaigns );
+	}
+}


### PR DESCRIPTION
### What and why? 🤔

We were missing some unit tests on the `Blaze_Marketing_Channel` class. Because that class implements an abstract Woo class, most of the methods were not directly used in our plugin. That caused the IDE to show us unused warnings.

I am including some basic unit testing on that class to ensure coverage and remove unused warnings just to prevent future deletions that will result in fatal errors in the plugin.

### Testing Steps ✍️

* Install this plugin version alongside with WooCommerce
* Go to Marketing->Overview and verify that you can see the Blazde Ads marketing channel

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [x] New tests have been added
