### PR TITLE
Remove step based permissions

### DIFF
--- a/.github/workflows/release-build-zip.yml
+++ b/.github/workflows/release-build-zip.yml
@@ -17,7 +17,8 @@ on:
         description: "Branch to be used for building zip file"
 
 permissions:
-  contents: read
+  contents: read # Needed for checking out the repository
+  actions: write # Needed for uploading the artifact
 
 jobs:
   build-zip:
@@ -46,8 +47,6 @@ jobs:
 
       - name: "Upload the zip file as an artifact"
         uses: actions/upload-artifact@v3
-        permissions:
-          actions: write  # Permissions needed for uploading the artifact
         with:
           name: "blaze-ads"
           path: release

--- a/.github/workflows/release-generate.yml
+++ b/.github/workflows/release-generate.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read  # Default permissions for the workflow
+  contents: write # needs write permissions to create a tag
 
 defaults:
   run:
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releaseVersion: ${{ steps.current-version.outputs.RELEASE_VERSION }}
-    permissions:
-      contents: read  # Checkout only requires read access to repository contents
 
     steps:
       - name: "Checkout repository (trunk)"
@@ -39,8 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.get-last-released-version.outputs.releaseVersion }}
-    permissions:
-      contents: write  # This job needs write access to create the tag and the release
 
     steps:
       - name: "Checkout repository (trunk)"
@@ -81,5 +77,3 @@ jobs:
         run: |
           RELEASE_NOTES=$(echo -e "${CHANGELOG}")
           gh release create $RELEASE_VERSION --notes "$RELEASE_NOTES" --title "$TAG_MESSAGE" $FILENAME
-        permissions:
-          contents: write  # Required for creating a release in the GitHub repository

--- a/changelog/action-permission-fixes
+++ b/changelog/action-permission-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removes permissions that were on the step level, this is not supported and caused action failures


### PR DESCRIPTION
See [failed job](https://github.com/Automattic/blaze-ads/actions/runs/11107281679)
### What and why? 🤔

Step based permissions are not supported, so I've moved this up to job level

### Testing Steps ✍️

Code review please :)


### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
