### PR TITLE
Add permissions to release pr

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,8 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: read   # Required for repository access
+  actions: write   # Required to allow the `release-build-zip.yml` workflow to upload artifacts
 
 defaults:
   run:

--- a/changelog/release-pr-permissions
+++ b/changelog/release-pr-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fixing "The workflow is requesting 'actions: write', but is only allowed 'actions: none'."


### PR DESCRIPTION

### What and why? 🤔

Attempt to fix an error:
> The workflow is requesting 'actions: write', but is only allowed 'actions: none'.

### Testing Steps ✍️

Code review

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
