### PR TITLE
Update cache/checkout to v4, for node 20 compatibility

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !contains(github.head_ref, 'release/') }}
     steps:
       # clone the repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Set up Repository (PHP only)."
         uses: ./.github/actions/setup-repo
         with:

--- a/.github/workflows/release-build-zip.yml
+++ b/.github/workflows/release-build-zip.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.repo-branch || github.ref }}
 

--- a/.github/workflows/release-generate.yml
+++ b/.github/workflows/release-generate.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'trunk'
 
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: "Checkout repository (trunk)"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: 'trunk'
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up repository"
         uses: ./.github/actions/setup-repo


### PR DESCRIPTION
### What and why? 🤔

Fix warning:

![Screenshot 2024-09-30 at 16 58 10](https://github.com/user-attachments/assets/bd8a50ff-c686-4ec3-bf15-1360a56dbd9b)

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

### Testing Steps ✍️

Code review

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
