### PR TITLE
Release branch for 0.5.0

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.4.1
+ * Version: 0.5.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 *** Blaze Ads Changelog ***
 
+2024-09-30 - version 0.5.0
+* Fix - fixing "The workflow is requesting 'actions: write', but is only allowed 'actions: none'."
+* Fix - Reinstate GH token in release PR action
+* Fix - Removes old dashboard compatibility classes. They are no longer needed
+* Fix - Removes permissions that were on the step level, this is not supported and caused action failures
+* Update - Changes the menu slug from wc-blaze to wp-blaze
+* Update - Improves the handling of the DSP API responses
+* Update - minor code cleanups, type hinting, access modifiers, return types
+* Update - Refactors the rest of the files to follow the new plugin's name
+* Update - Removes a reference to a remote image, and brings it into the plugin
+* Update - Removes the custom translation code to start using the default dotorg mechanism
+* Update - Update action permissions on a per job basis
+* Dev - Adds composer.json to the release build
+
 2024-08-19 - version 0.4.1
 * Dev - fix concerns reported by running Plugin Check (PCP)
 

--- a/changelog/action-permission-fixes
+++ b/changelog/action-permission-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Removes permissions that were on the step level, this is not supported and caused action failures

--- a/changelog/action-permissions
+++ b/changelog/action-permissions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update action permissions on a per job basis

--- a/changelog/add-marketing-channel-unit-tests
+++ b/changelog/add-marketing-channel-unit-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Adds unit testing to the Marketing channel implementation
-
-

--- a/changelog/adds composer.json to the release build
+++ b/changelog/adds composer.json to the release build
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Adds composer.json to the release build

--- a/changelog/change-menu-slug-from-wc
+++ b/changelog/change-menu-slug-from-wc
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Changes the menu slug from wc-blaze to wp-blaze

--- a/changelog/fix-assets-plugin-dir
+++ b/changelog/fix-assets-plugin-dir
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fixes a problem with assets dir after merging rename refactor
-
-

--- a/changelog/fix-release-note-changelog
+++ b/changelog/fix-release-note-changelog
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Fixes the changelog we extract for the release notes
-
-

--- a/changelog/fix-script-tag-usage-in-compat-file
+++ b/changelog/fix-script-tag-usage-in-compat-file
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Removes old dashboard compatibility classes. They are no longer needed

--- a/changelog/minor-code-cleanup
+++ b/changelog/minor-code-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-minor code cleanups, type hinting, access modifiers, return types

--- a/changelog/reinstate GH token in actions
+++ b/changelog/reinstate GH token in actions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Reinstate GH token in release PR action

--- a/changelog/release-pr-permissions
+++ b/changelog/release-pr-permissions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fixing "The workflow is requesting 'actions: write', but is only allowed 'actions: none'."

--- a/changelog/remove-remote-image
+++ b/changelog/remove-remote-image
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Removes a reference to a remote image, and brings it into the plugin

--- a/changelog/update-improves-request-dsp-utility
+++ b/changelog/update-improves-request-dsp-utility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Improves the handling of the DSP API responses

--- a/changelog/update-plugin-documentation
+++ b/changelog/update-plugin-documentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: update
-Comment: Plugin's documentation updated
-
-

--- a/changelog/update-removes-custom-translation-hook
+++ b/changelog/update-removes-custom-translation-hook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Removes the custom translation code to start using the default dotorg mechanism

--- a/changelog/update-woo-blaze-to-blaze-ads
+++ b/changelog/update-woo-blaze-to-blaze-ads
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Refactors the rest of the files to follow the new plugin's name

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.4.1
+Stable tag: 0.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -60,6 +60,20 @@ If your site uses WooCommerce, you’ll also find Blaze Ads alongside your other
 Yes, you can review our [Terms of Service](https://wordpress.com/tos/), our [Privacy Policy](https://automattic.com/privacy/) and our [Advertising Policy](https://automattic.com/advertising-policy/) for full details on how we handle data and ensure compliance.
 
 == Changelog ==
+
+= 0.5.0 - 2024-09-30 =
+* Fix - fixing "The workflow is requesting 'actions: write', but is only allowed 'actions: none'."
+* Fix - Reinstate GH token in release PR action
+* Fix - Removes old dashboard compatibility classes. They are no longer needed
+* Fix - Removes permissions that were on the step level, this is not supported and caused action failures
+* Update - Changes the menu slug from wc-blaze to wp-blaze
+* Update - Improves the handling of the DSP API responses
+* Update - minor code cleanups, type hinting, access modifiers, return types
+* Update - Refactors the rest of the files to follow the new plugin's name
+* Update - Removes a reference to a remote image, and brings it into the plugin
+* Update - Removes the custom translation code to start using the default dotorg mechanism
+* Update - Update action permissions on a per job basis
+* Dev - Adds composer.json to the release build
 
 = 0.4.1 - 2024-08-19 =
 * Dev - fix concerns reported by running Plugin Check (PCP)


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [x] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Fix - fixing "The workflow is requesting 'actions: write', but is only allowed 'actions: none'."
* Fix - Reinstate GH token in release PR action
* Fix - Removes old dashboard compatibility classes. They are no longer needed
* Fix - Removes permissions that were on the step level, this is not supported and caused action failures
* Update - Changes the menu slug from wc-blaze to wp-blaze
* Update - Improves the handling of the DSP API responses
* Update - minor code cleanups, type hinting, access modifiers, return types
* Update - Refactors the rest of the files to follow the new plugin's name
* Update - Removes a reference to a remote image, and brings it into the plugin
* Update - Removes the custom translation code to start using the default dotorg mechanism
* Update - Update action permissions on a per job basis
* Dev - Adds composer.json to the release build
```