### PR TITLE
Add GH SVN dependency to CI scripts

### DIFF
--- a/bin/run-ci-tests.sh
+++ b/bin/run-ci-tests.sh
@@ -10,6 +10,12 @@ BLAZEADS_DIR="$GITHUB_WORKSPACE"
 echo 'Updating composer version & Install dependencies...'
 composer self-update && composer install --no-progress
 
+# SVN is needed when installing WP.
+if ! [ -x "$(command -v svn)" ]; then
+	echo 'Installing SVN...'
+	sudo apt-get install -y subversion
+fi
+
 echo 'Starting MySQL service...'
 sudo systemctl start mysql.service
 

--- a/changelog/fix-add-svn-ci-scripts
+++ b/changelog/fix-add-svn-ci-scripts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add GH action SVN dependency
+
+


### PR DESCRIPTION
See: [GH Action failed logs](https://github.com/Automattic/blaze-ads/actions/runs/12583334688/job/35072651911)

### What and why? 🤔

We are getting an error on the [Linting and Testing
](https://github.com/Automattic/blaze-ads/actions/workflows/lint-and-test.yml) GH action about a missing svn command:

```
bin/install-wp-tests.sh: line 152: svn: command not found
Error: Process completed with exit code 127.
```

The script `bin/install-wp-tests.sh` requires SVN to check out the WordPress plugin and install it, so we must add that dependency to the CI scripts.

### Testing Steps ✍️

Code review, and check that the CI tasks are all green.

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
