### PR TITLE
Fixes the MCM check for the Woo marketing logic

### DIFF
--- a/changelog/fix-fixes-mcm-check
+++ b/changelog/fix-fixes-mcm-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a compatibility bug with with newer versions of WooCommerce

--- a/includes/class-blaze-marketing-channel.php
+++ b/includes/class-blaze-marketing-channel.php
@@ -66,7 +66,7 @@ class Blaze_Marketing_Channel implements MarketingChannelInterface {
 	 */
 	public function can_register_marketing_channel(): bool {
 		// Check if the Multichannel Marketing plugin is active.
-		if ( ! defined( 'WC_MCM_EXISTS' ) ) {
+		if ( ! class_exists( MarketingChannels::class ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### What and why? 🤔

One of the latest versions of WooCommerce broke a check that we have related to the existence of MarketingChannels.
This check prevents the initialization of the marketing channel. The dashboard works fine, but the channel is not displayed on the Marketing -> Overview page.

I am changing the check to stop using the variable `WC_MCM_EXISTS ` and just check for the existence of the class `MarketingChannels` that is the one we use in our code.

I checked other marketing channels plugin, and they made this same change too.

### Testing Steps ✍️

* Install this plugin version in any site with WooCommerce
* Check that you see the Blaze Ads marketing channel in the Marketing -> Overview page
![Screenshot 2025-01-02 at 1 58 47 PM](https://github.com/user-attachments/assets/83321662-f206-4425-95c6-8545adbb4348)
* Run a smoke test of the dashboard just to confirm that it still works fine

### Review checklist
- [ ] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
