### PR TITLE
Release branch for 0.5.3

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.5.2
+ * Version: 0.5.3
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Blaze Ads Changelog ***
 
+2025-01-06 - version 0.5.3
+* Fix - Fixes a compatibility bug with with newer versions of WooCommerce
+* Update - Updates composer dependencies to use the new Blaze package version
+
 2024-10-31 - version 0.5.2
 * Add - Adds the assets for the DotOrg directory
 * Update - updates composer dependency for the Blaze package

--- a/changelog/fix-add-svn-ci-scripts
+++ b/changelog/fix-add-svn-ci-scripts
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Add GH action SVN dependency
-
-

--- a/changelog/fix-fixes-mcm-check
+++ b/changelog/fix-fixes-mcm-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes a compatibility bug with with newer versions of WooCommerce

--- a/changelog/update-composer-jetpack-dependencies
+++ b/changelog/update-composer-jetpack-dependencies
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Updates composer dependencies to use the new Blaze package version

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.5.2
+Stable tag: 0.5.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -70,6 +70,10 @@ Yes, you can review our [Terms of Service](https://wordpress.com/tos/), our [Pri
 6. See how your campaign has performed!
 
 == Changelog ==
+
+= 0.5.3 - 2025-01-06 =
+* Fix - Fixes a compatibility bug with with newer versions of WooCommerce
+* Update - Updates composer dependencies to use the new Blaze package version
 
 = 0.5.2 - 2024-10-31 =
 * Add - Adds the assets for the DotOrg directory


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [x] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Fix - Fixes a compatibility bug with with newer versions of WooCommerce
* Update - Updates composer dependencies to use the new Blaze package version
```