### PR TITLE
Updates PNPM and mariadb versions

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: pnpm/action-setup@v3
       if: ${{ inputs.setup-node-pnpm == 'true' }}
       with:
-        version: 9
+        version: 10
     - name: "Set up Node"
       uses: actions/setup-node@v4
       if: ${{ inputs.setup-node-pnpm == 'true' }}

--- a/changelog/update-pnpm-mariadb-versions
+++ b/changelog/update-pnpm-mariadb-versions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Updates pnpm and mariadb version
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - 'host.docker.internal:host-gateway'
   db:
     container_name: blaze_ads_mysql
-    image: mariadb:10.5.8
+    image: mariadb:11.4.5
     ports:
       - '3308:3306'
     env_file:

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
 		"pnpm": "^10.8.0"
 	},
 	"scripts": {
-		"docker:up": "docker-compose up --build -d",
-		"docker:up:recreate": "docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh",
-		"docker:down": "docker-compose down",
+		"docker:up": "docker compose up --build -d",
+		"docker:up:recreate": "docker compose up --build --force-recreate -d && ./bin/docker-setup.sh",
+		"docker:down": "docker compose down",
 		"build": "pnpm build:deps && pnpm i18n:pot && pnpm build:release",
 		"build:deps": "rm -rf vendor && composer install --no-dev --optimize-autoloader",
 		"build:release": "node bin/release-task.js && mv release/$npm_package_name.zip .",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",
-		"pnpm": "^9.3.0"
+		"pnpm": "^10.8.0"
 	},
 	"scripts": {
 		"docker:up": "docker-compose up --build -d",


### PR DESCRIPTION
### What and why? 🤔

When I started the docker environment, I got errors about myqlcheck being deprecated and having troubles connecting using SSL. I am updating the version of our localdb to 11.4, that is the one supported by the previous version of WordPress

I also took the chance to update the pnpm version.

### Testing Steps ✍️

* Checkout this branch and execute: `pnpm docker:up:recreate`
* Check that the environment starts correctly

### Review checklist
- [x] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
