### PR TITLE
Update actions/upload-artifact from v3 to v4 to use the latest version

### DIFF
--- a/.github/workflows/release-build-zip.yml
+++ b/.github/workflows/release-build-zip.yml
@@ -42,7 +42,7 @@ jobs:
           echo ":information_source: Ignore the artifact size mentioned since GitHub calculates the size of the source folder instead of the zip file created." >> $GITHUB_STEP_SUMMARY
 
       - name: "Upload the zip file as an artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/changelog/fix-release-build-zip-workflow
+++ b/changelog/fix-release-build-zip-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update actions/upload-artifact from v3 to v4 to use the latest version


### PR DESCRIPTION
### What and why? 🤔

The workflow [Release - Prepare a release PR to trunk 
](https://github.com/Automattic/blaze-ads/actions/runs/16006643382/job/45154800288) is throwing an error because a deprecated action. 

![Screenshot 2025-07-01 at 3 05 54 PM](https://github.com/user-attachments/assets/5e20524b-97a2-4d5c-a398-3e539cde1454)

This PR will update the action `actions/upload-artifact` to `v4`.

### Testing Steps ✍️

* Navigate to the workflow [Release - Prepare a release PR to trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-pr.yml)
* Run the workflow but using this branch as base (follow the screenshot data)
![Screenshot 2025-07-01 at 3 14 36 PM](https://github.com/user-attachments/assets/67add00d-f79e-462b-b333-4a2fc0f34f9e)
* Verify that the workflow completed successfuly
* Go to the Pull Request page on GitHub and verify that you have the release PR for the version you selected on the previous step
* Access the PR, close it, and then delete the branch to clear up the data (they won't be needed).

Provide adequate testing steps.
Don't assume someone knows how to test your changes; be thorough.

### Review checklist
- [ ] Run `pnpm changelog` to add a changelog file, choose `patch` to leave it empty if the change is not significant. You can add multiple changelog files in one PR by running this command a few times.
- [ ] New tests have been added
