### PR TITLE
Release branch for 0.7.0

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.6.0
+ * Version: 0.7.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Blaze Ads Changelog ***
 
+2025-07-02 - version 0.7.0
+* Fix - Fixes the i18n notices on the plugin (Jetpack IDC config and marketing channel descriptions)
+* Fix - Update actions/upload-artifact from v3 to v4 to use the latest version
+
 2025-01-08 - version 0.6.0
 * Update - Updates the plugin documentation page
 

--- a/changelog/fix-release-build-zip-workflow
+++ b/changelog/fix-release-build-zip-workflow
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Update actions/upload-artifact from v3 to v4 to use the latest version

--- a/changelog/fix-translation-early-call
+++ b/changelog/fix-translation-early-call
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fixes the i18n notices on the plugin (Jetpack IDC config and marketing channel descriptions)

--- a/changelog/update-pnpm-mariadb-versions
+++ b/changelog/update-pnpm-mariadb-versions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: update
-Comment: Updates pnpm and mariadb version
-
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.6.0
+Stable tag: 0.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,10 @@ Yes, you can review our [Terms of Service](https://wordpress.com/tos/), our [Pri
 6. See how your campaign has performed!
 
 == Changelog ==
+
+= 0.7.0 - 2025-07-02 =
+* Fix - Fixes the i18n notices on the plugin (Jetpack IDC config and marketing channel descriptions)
+* Fix - Update actions/upload-artifact from v3 to v4 to use the latest version
 
 = 0.6.0 - 2025-01-08 =
 * Update - Updates the plugin documentation page


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [x] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Fix - Fixes the i18n notices on the plugin (Jetpack IDC config and marketing channel descriptions)
* Fix - Update actions/upload-artifact from v3 to v4 to use the latest version
```