### PR TITLE
Bump the version of the blaze ads plugin to add the new payments tab in the dashboard

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.7.0
+ * Version: 0.8.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog/2025-08-04-12-59-37-702078
+++ b/changelog/2025-08-04-12-59-37-702078
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+New version with payments tab in dashboard

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.7.0
+Stable tag: 0.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
See: (other PR, issue link, etc).

### What and why? 🤔

Relates to the blaze orders/payments linear project

### Testing Steps ✍️

This is a PR to only bump the version of the plugin. we use the version 0.8.0 in the blaze dashboard to include the payments functionality

this needs to be merged after the calypso [PR](https://github.com/Automattic/wp-calypso/pull/104901) related to the payments have been deployed (and the blaze dashboard updated)


### Review checklist
CR is enough i think
