### PR TITLE
Release branch for 0.8.0

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.7.0
+ * Version: 0.8.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Blaze Ads Changelog ***
 
+2025-08-12 - version 0.8.0
+* Update - update jetpack-blaze package to use latest version
+
 2025-07-02 - version 0.7.0
 * Fix - Fixes the i18n notices on the plugin (Jetpack IDC config and marketing channel descriptions)
 * Fix - Update actions/upload-artifact from v3 to v4 to use the latest version

--- a/changelog/update-jetpack-blaze-package
+++ b/changelog/update-jetpack-blaze-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-update jetpack-blaze package to use latest version

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.7.0
+Stable tag: 0.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ Yes, you can review our [Terms of Service](https://wordpress.com/tos/), our [Pri
 6. See how your campaign has performed!
 
 == Changelog ==
+
+= 0.8.0 - 2025-08-12 =
+* Update - update jetpack-blaze package to use latest version
 
 = 0.7.0 - 2025-07-02 =
 * Fix - Fixes the i18n notices on the plugin (Jetpack IDC config and marketing channel descriptions)


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [x] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Update - update jetpack-blaze package to use latest version
```