### PR TITLE
Release branch for 0.9.0

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Blaze Ads
  * Plugin URI: https://github.com/automattic/blaze-ads
  * Description: One-click and you're set! Create ads for your products and store simpler than ever. Get started now and watch your business grow.
- * Version: 0.8.1
+ * Version: 0.9.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Text Domain: blaze-ads

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Blaze Ads Changelog ***
 
+2026-01-27 - version 0.9.0
+* Update - Update Jetpack dependencies to latest versions
+
 2026-01-13 - version 0.8.1
 * Update - Updates the latest tested version and readme
 * Update - Updates the Woo logo from the Woo purple to blaze orange flame

--- a/changelog/fix-release-pr-workflow
+++ b/changelog/fix-release-pr-workflow
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fixes the env variable used in the release-pr workflow
-
-

--- a/changelog/update-jetpack-packages
+++ b/changelog/update-jetpack-packages
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update Jetpack dependencies to latest versions

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "blaze-ads",
 	"title": "Blaze Ads",
 	"license": "GPL-2.0-or-later",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Blaze Ads",
 	"engines": {
 		"node": "^20.8.1",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: blaze ads, woo blaze, blaze, advertising
 Requires at least: 6.3
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 0.8.1
+Stable tag: 0.9.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,9 @@ Yes, you can review our [Terms of Service](https://wordpress.com/tos/), our [Pri
 6. See how your campaign has performed!
 
 == Changelog ==
+
+= 0.9.0 - 2026-01-27 =
+* Update - Update Jetpack dependencies to latest versions
 
 = 0.8.1 - 2026-01-13 =
 * Update - Updates the latest tested version and readme


### PR DESCRIPTION
:warning: Please complete these checks before finishing the release. :warning:

- [x] The plugin version is bumped (`package.json` and `blaze-ads.php`)
- [x] The `changelog.txt` file is correct, and the entries from `/changelog` folder were deleted
- [x] CI checks are passing
- [x] Smoke test the plugin using the generated zip file (found in a comment below)

All good ✅ ? Then, feel free to merge this PR and, after that, execute the [Release - Tag and release trunk](https://github.com/Automattic/blaze-ads/actions/workflows/release-generate.yml) to finish the GitHub release.
#### Changelog:
```
* Update - Update Jetpack dependencies to latest versions
```