### PR TITLE
Rename non-Woo menu to Blaze Ads and add campaign-based top-level promotion

### DIFF
--- a/blaze-ads.php
+++ b/blaze-ads.php
@@ -53,11 +53,12 @@ function blazeads_jetpack_init() {
 		)
 	);
 
-	$is_woo_store = Blaze_Dependency_Service::is_woo_core_active();
-	$idc_config   = array(
+	$is_woo_store   = Blaze_Dependency_Service::is_woo_core_active();
+	$admin_page_url = '/wp-admin/' . ( new BlazeAds\Blaze_Dashboard() )->get_admin_page_url_path();
+	$idc_config     = array(
 		'slug'          => 'blaze-ads',
 		'customContent' => $custom_content,
-		'admin_page'    => $is_woo_store ? '/wp-admin/admin.php?page=wp-blaze' : '/wp-admin/tools.php?page=wp-blaze',
+		'admin_page'    => $admin_page_url,
 		'priority'      => 5,
 	);
 

--- a/changelog/add-blaze-ads-menu-revisions-redirect-fix
+++ b/changelog/add-blaze-ads-menu-revisions-redirect-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Widen legacy advertising URL redirect to also accept admin.php entry point.

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -75,18 +75,15 @@ class Blaze_Dashboard {
 	}
 
 	/**
-	 * Determines whether the non-Woo menu should be promoted to a top-level menu page.
+	 * Determines whether the menu should be promoted to a top-level menu page.
 	 *
-	 * The menu is promoted when the site is not a WooCommerce store and has active
-	 * Blaze campaigns. This makes the Blaze Ads entry more visible in the admin sidebar.
+	 * The menu is promoted when the site has active Blaze campaigns, regardless
+	 * of whether WooCommerce is active. This makes the Blaze Ads entry more
+	 * visible in the admin sidebar.
 	 *
 	 * @return bool True if the menu should be a top-level page.
 	 */
 	public function should_promote_to_top_level(): bool {
-		if ( $this->can_display_marketing_menu() ) {
-			return false;
-		}
-
 		return self::has_active_campaigns();
 	}
 
@@ -136,17 +133,18 @@ class Blaze_Dashboard {
 	/**
 	 * Returns the admin page base for the Blaze Ads dashboard.
 	 *
-	 * For WooCommerce stores the dashboard lives under admin.php. For non-Woo sites
-	 * it is either admin.php (when promoted to top-level) or tools.php (submenu fallback).
+	 * When promoted to top-level (active campaigns in any context) or displayed
+	 * under the WooCommerce Marketing submenu, the base is admin.php. Otherwise,
+	 * for non-Woo sites without active campaigns, it falls back to tools.php.
 	 *
 	 * @return string The page base, e.g. 'admin.php' or 'tools.php'.
 	 */
 	public function get_admin_page_base(): string {
-		if ( $this->can_display_marketing_menu() ) {
+		if ( $this->should_promote_to_top_level() ) {
 			return 'admin.php';
 		}
 
-		if ( $this->should_promote_to_top_level() ) {
+		if ( $this->can_display_marketing_menu() ) {
 			return 'admin.php';
 		}
 
@@ -166,22 +164,12 @@ class Blaze_Dashboard {
 	 * Adds Blaze entry point to the menu under the Marketing section.
 	 */
 	public function add_admin_menu(): void {
-		$menu_slug              = 'wp-blaze';
-		$display_marketing_menu = $this->can_display_marketing_menu();
-		$promote_to_top_level   = $this->should_promote_to_top_level();
+		$menu_slug            = 'wp-blaze';
+		$promote_to_top_level = $this->should_promote_to_top_level();
 
 		$blaze_dashboard = new Jetpack_Blaze_Dashboard( $this->get_admin_page_base(), $menu_slug, 'woo-blaze' );
 
-		if ( $display_marketing_menu ) {
-			$page_suffix = add_submenu_page(
-				'woocommerce-marketing',
-				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
-				__( 'Blaze Ads', 'blaze-ads' ),
-				'manage_options',
-				$menu_slug,
-				array( $blaze_dashboard, 'render' )
-			);
-		} elseif ( $promote_to_top_level ) {
+		if ( $promote_to_top_level ) {
 			$page_suffix = add_menu_page(
 				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
 				__( 'Blaze Ads', 'blaze-ads' ),
@@ -190,6 +178,15 @@ class Blaze_Dashboard {
 				array( $blaze_dashboard, 'render' ),
 				'dashicons-megaphone',
 				30
+			);
+		} elseif ( $this->can_display_marketing_menu() ) {
+			$page_suffix = add_submenu_page(
+				'woocommerce-marketing',
+				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
+				__( 'Blaze Ads', 'blaze-ads' ),
+				'manage_options',
+				$menu_slug,
+				array( $blaze_dashboard, 'render' )
 			);
 		} else {
 			$page_suffix = add_submenu_page(
@@ -215,7 +212,7 @@ class Blaze_Dashboard {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( 'tools.php' === $pagenow && isset( $_GET['page'] ) && 'advertising' === $_GET['page'] ) {
-			wp_safe_redirect( admin_url( '/admin.php?page=wp-blaze', 'http' ), 302 );
+			wp_safe_redirect( admin_url( '/' . $this->get_admin_page_url_path(), 'http' ), 302 );
 			exit;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -88,7 +88,7 @@ class Blaze_Dashboard {
 		if ( isset( $_GET['page'] ) && 'wp-blaze' === $_GET['page'] ) {
 			$site_id = Jetpack_Connection_Manager::get_site_id();
 			if ( is_numeric( $site_id ) ) {
-				delete_transient( 'jetpack_blaze_has_active_campaigns_' . $site_id );
+				delete_transient( 'jetpack_blaze_has_site_campaigns_' . $site_id );
 			}
 		}
 	}

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -71,7 +71,7 @@ class Blaze_Dashboard {
 	 * @return bool
 	 */
 	public function should_enable_jetpack_blaze_menu(): bool {
-		return $this->can_display_marketing_menu();
+		return false;
 	}
 
 	/**
@@ -110,14 +110,10 @@ class Blaze_Dashboard {
 				return false;
 			}
 
-			$query_params = array(
-				'status' => 'active',
-			);
+			$path     = sprintf( 'v1/campaigns/site/%s/stats', $blog_id );
+			$response = Blaze_Ads_Utils::call_dsp_server( $blog_id, $path, 'GET' );
 
-			$path     = sprintf( 'v1/search/campaigns/site/%s', $blog_id );
-			$response = Blaze_Ads_Utils::call_dsp_server( $blog_id, $path, 'GET', $query_params );
-
-			if ( 200 === $response['status'] && isset( $response['body']['campaigns'] ) && ! empty( $response['body']['campaigns'] ) ) {
+			if ( 200 === $response['status'] && isset( $response['body']['total'] ) && ! empty( $response['body']['total'] ) ) {
 				$has_campaigns = true;
 			}
 		} catch ( Base_Exception $e ) {
@@ -200,6 +196,16 @@ class Blaze_Dashboard {
 			);
 		}
 		add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		add_action( 'load-' . $page_suffix, array( $this, 'invalidate_campaigns_cache' ) );
+	}
+
+	/**
+	 * Invalidates the active campaigns transient when the user loads the
+	 * Blaze Ads dashboard page. This ensures the menu position updates on
+	 * the next admin page load after a campaign is created or finishes.
+	 */
+	public function invalidate_campaigns_cache(): void {
+		delete_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT );
 	}
 
 	/**

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -10,7 +10,6 @@ namespace BlazeAds;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Blaze as Jetpack_Blaze;
-use Automattic\Jetpack\Blaze\Dashboard as Jetpack_Blaze_Dashboard;
 use Automattic\Jetpack\Modules as Jetpack_Modules;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 
@@ -19,18 +18,18 @@ use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
  */
 class Blaze_Dashboard {
 
-
 	/**
 	 * Initializes/configures the Jetpack Blaze module.
 	 */
 	public function initialize(): void {
 		// Configures the additional information we need in the state.
 		add_filter( 'jetpack_blaze_dashboard_config_data', array( $this, 'blaze_ads_initial_config_data' ), 10, 1 );
-		// Allow disabling of the Jetpack Blaze menu for non-Woo sites, to avoid showing 2 advertising sub menus in the Tools menu.
-		add_filter( 'jetpack_blaze_enabled', array( $this, 'should_enable_jetpack_blaze_menu' ), 10, 1 );
 
-		// Add initial actions.
-		add_action( 'admin_menu', array( $this, 'add_admin_menu' ), 999 );
+		// Customize jetpack-blaze menu registration via filters (slug, CSS prefix).
+		add_filter( 'jetpack_blaze_menu_slug', array( $this, 'get_menu_slug' ) );
+		add_filter( 'jetpack_blaze_dashboard_css_prefix', array( $this, 'get_css_prefix' ) );
+
+		// Redirect legacy ?page=advertising URLs to ?page=wp-blaze.
 		add_action( 'admin_menu', array( $this, 'jetpack_dashboard_redirection' ), 999 );
 		add_action(
 			'admin_init',
@@ -38,7 +37,10 @@ class Blaze_Dashboard {
 			1000
 		); // Run this after dashboard redirect.
 
-		// We initialize the module ony if we are running standalone, or if Jetpack Blaze is enabled inside Jetpack plugin.
+		// Invalidate jetpack-blaze campaign cache on dashboard page load.
+		add_action( 'admin_init', array( $this, 'maybe_invalidate_campaigns_cache' ) );
+
+		// We initialize the module only if we are running standalone, or if Jetpack Blaze is enabled inside Jetpack plugin.
 		// We don't want to override the user's decision to disable Blaze. We have a specific page that shows how to re-enable it.
 		if ( $this->is_blaze_module_active() ) {
 			Jetpack_Blaze::init();
@@ -46,98 +48,53 @@ class Blaze_Dashboard {
 	}
 
 	/**
-	 * Checks if the Marketing Blaze submenu can be displayed on the site.
+	 * Returns the menu slug used by Blaze Ads.
 	 *
-	 * @return bool
+	 * Hooked to `jetpack_blaze_menu_slug` to override the default 'advertising'.
+	 *
+	 * @return string
 	 */
-	public function can_display_marketing_menu(): bool {
-		return Blaze_Dependency_Service::is_woo_core_active();
+	public function get_menu_slug(): string {
+		return 'wp-blaze';
 	}
 
 	/**
-	 * Checks if the Jetpack Blaze menu should be enabled.
+	 * Returns the CSS prefix for the Blaze Ads dashboard.
 	 *
-	 * Always returns false because blaze-ads registers its own menu in
-	 * add_admin_menu(). This prevents the jetpack-blaze package from
-	 * creating a duplicate entry.
+	 * Hooked to `jetpack_blaze_dashboard_css_prefix` to override the default 'jp-blaze'.
 	 *
-	 * @return bool
+	 * @return string
 	 */
-	public function should_enable_jetpack_blaze_menu(): bool {
-		return false;
+	public function get_css_prefix(): string {
+		return 'woo-blaze';
 	}
 
 	/**
-	 * Checks if the Jetpack top-level admin menu is registered.
+	 * Returns the full admin URL path for the Blaze Ads dashboard page.
 	 *
-	 * @return bool True if the 'jetpack' top-level menu exists.
+	 * @return string E.g. 'admin.php?page=wp-blaze'.
 	 */
-	private static function is_jetpack_parent_available(): bool {
-		global $menu;
-		foreach ( (array) $menu as $item ) {
-			if ( isset( $item[2] ) && 'jetpack' === $item[2] ) {
-				return true;
+	public function get_admin_page_url_path(): string {
+		return 'admin.php?page=wp-blaze';
+	}
+
+	/**
+	 * Invalidates the jetpack-blaze active campaigns transient when the user
+	 * loads the Blaze Ads dashboard page. This ensures the menu position
+	 * updates on the next admin page load after a campaign is created.
+	 */
+	public function maybe_invalidate_campaigns_cache(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && 'wp-blaze' === $_GET['page'] ) {
+			$site_id = Jetpack_Connection_Manager::get_site_id();
+			if ( is_numeric( $site_id ) ) {
+				delete_transient( 'jetpack_blaze_has_site_campaigns_' . $site_id );
 			}
 		}
-		return false;
 	}
 
 	/**
-	 * Adds Blaze entry point to the menu under the Marketing section.
-	 */
-	public function add_admin_menu(): void {
-		$menu_slug       = 'advertising';
-		$parent_slug     = $this->get_menu_parent();
-		$page_base       = 'tools.php' === $parent_slug ? 'tools.php' : 'admin.php';
-		$blaze_dashboard = new Jetpack_Blaze_Dashboard( $page_base, $menu_slug, 'woo-blaze' );
-
-		if ( 'tools.php' === $parent_slug ) {
-			// Fallback: no Jetpack, no WooCommerce — register under Tools.
-			$page_suffix = add_submenu_page(
-				'tools.php',
-				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
-				__( 'Blaze Ads', 'blaze-ads' ),
-				'manage_options',
-				$menu_slug,
-				array( $blaze_dashboard, 'render' ),
-				1
-			);
-		} else {
-			// Register under Jetpack or WooCommerce Marketing — both resolve at admin.php.
-			$page_suffix = add_submenu_page(
-				$parent_slug,
-				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
-				__( 'Blaze Ads', 'blaze-ads' ),
-				'manage_options',
-				$menu_slug,
-				array( $blaze_dashboard, 'render' ),
-				1
-			);
-		}
-		add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
-	}
-
-	/**
-	 * Returns the parent menu slug for the Blaze Ads submenu.
-	 *
-	 * Priority: WooCommerce Marketing > Jetpack > Tools.
-	 *
-	 * @return string Parent menu slug.
-	 */
-	private function get_menu_parent(): string {
-		if ( $this->can_display_marketing_menu() ) {
-			return 'woocommerce-marketing';
-		}
-
-		if ( self::is_jetpack_parent_available() ) {
-			return 'jetpack';
-		}
-
-		return 'tools.php';
-	}
-
-	/**
-	 * Handles the redirection from the legacy wp-blaze slug to the current advertising slug.
+	 * Handles the redirection from the Jetpack Blaze dashboard URL to the new Blaze Ads dashboard
 	 *
 	 * @return void
 	 */
@@ -145,10 +102,10 @@ class Blaze_Dashboard {
 		global $pagenow;
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['page'] ) && 'wp-blaze' === $_GET['page']
+		if ( isset( $_GET['page'] ) && 'advertising' === $_GET['page']
 			&& in_array( $pagenow, array( 'tools.php', 'admin.php' ), true )
 		) {
-			wp_safe_redirect( admin_url( 'admin.php?page=advertising' ), 302 );
+			wp_safe_redirect( admin_url( '/' . $this->get_admin_page_url_path(), 'http' ), 302 );
 			exit;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -175,7 +132,7 @@ class Blaze_Dashboard {
 		$setup_reason = $this->check_setup_plugin_status();
 
 		$data['is_blaze_plugin']       = true;
-		$data['dashboard_path_prefix'] = '/advertising';
+		$data['dashboard_path_prefix'] = '/wp-blaze';
 		$data['is_woo_store']          = Blaze_Dependency_Service::is_woo_core_active();
 		$data['need_setup']            = $setup_reason ?? false;
 
@@ -249,7 +206,7 @@ class Blaze_Dashboard {
 	 * @return string Jetpack connect url.
 	 */
 	public function get_connect_url( string $blazeads_connect_from = '1' ): string {
-		$admin_page = 'admin.php?page=advertising';
+		$admin_page = $this->get_admin_page_url_path();
 		$url        = add_query_arg(
 			array( 'blaze-ads-connect' => $blazeads_connect_from ),
 			admin_url( $admin_page )

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -211,7 +211,9 @@ class Blaze_Dashboard {
 		global $pagenow;
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( 'tools.php' === $pagenow && isset( $_GET['page'] ) && 'advertising' === $_GET['page'] ) {
+		if ( isset( $_GET['page'] ) && 'advertising' === $_GET['page']
+			&& in_array( $pagenow, array( 'tools.php', 'admin.php' ), true )
+		) {
 			wp_safe_redirect( admin_url( '/' . $this->get_admin_page_url_path(), 'http' ), 302 );
 			exit;
 		}

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -10,6 +10,7 @@ namespace BlazeAds;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Blaze as Jetpack_Blaze;
+use Automattic\Jetpack\Blaze\Dashboard as Jetpack_Blaze_Dashboard;
 use Automattic\Jetpack\Modules as Jetpack_Modules;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 
@@ -18,18 +19,18 @@ use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
  */
 class Blaze_Dashboard {
 
+
 	/**
 	 * Initializes/configures the Jetpack Blaze module.
 	 */
 	public function initialize(): void {
 		// Configures the additional information we need in the state.
 		add_filter( 'jetpack_blaze_dashboard_config_data', array( $this, 'blaze_ads_initial_config_data' ), 10, 1 );
+		// Allow disabling of the Jetpack Blaze menu for non-Woo sites, to avoid showing 2 advertising sub menus in the Tools menu.
+		add_filter( 'jetpack_blaze_enabled', array( $this, 'should_enable_jetpack_blaze_menu' ), 10, 1 );
 
-		// Customize jetpack-blaze menu registration via filters (slug, CSS prefix).
-		add_filter( 'jetpack_blaze_menu_slug', array( $this, 'get_menu_slug' ) );
-		add_filter( 'jetpack_blaze_dashboard_css_prefix', array( $this, 'get_css_prefix' ) );
-
-		// Redirect legacy ?page=advertising URLs to ?page=wp-blaze.
+		// Add initial actions.
+		add_action( 'admin_menu', array( $this, 'add_admin_menu' ), 999 );
 		add_action( 'admin_menu', array( $this, 'jetpack_dashboard_redirection' ), 999 );
 		add_action(
 			'admin_init',
@@ -37,10 +38,7 @@ class Blaze_Dashboard {
 			1000
 		); // Run this after dashboard redirect.
 
-		// Invalidate jetpack-blaze campaign cache on dashboard page load.
-		add_action( 'admin_init', array( $this, 'maybe_invalidate_campaigns_cache' ) );
-
-		// We initialize the module only if we are running standalone, or if Jetpack Blaze is enabled inside Jetpack plugin.
+		// We initialize the module ony if we are running standalone, or if Jetpack Blaze is enabled inside Jetpack plugin.
 		// We don't want to override the user's decision to disable Blaze. We have a specific page that shows how to re-enable it.
 		if ( $this->is_blaze_module_active() ) {
 			Jetpack_Blaze::init();
@@ -48,53 +46,98 @@ class Blaze_Dashboard {
 	}
 
 	/**
-	 * Returns the menu slug used by Blaze Ads.
+	 * Checks if the Marketing Blaze submenu can be displayed on the site.
 	 *
-	 * Hooked to `jetpack_blaze_menu_slug` to override the default 'advertising'.
-	 *
-	 * @return string
+	 * @return bool
 	 */
-	public function get_menu_slug(): string {
-		return 'wp-blaze';
+	public function can_display_marketing_menu(): bool {
+		return Blaze_Dependency_Service::is_woo_core_active();
 	}
 
 	/**
-	 * Returns the CSS prefix for the Blaze Ads dashboard.
+	 * Checks if the Jetpack Blaze menu should be enabled.
 	 *
-	 * Hooked to `jetpack_blaze_dashboard_css_prefix` to override the default 'jp-blaze'.
+	 * Always returns false because blaze-ads registers its own menu in
+	 * add_admin_menu(). This prevents the jetpack-blaze package from
+	 * creating a duplicate entry.
 	 *
-	 * @return string
+	 * @return bool
 	 */
-	public function get_css_prefix(): string {
-		return 'woo-blaze';
+	public function should_enable_jetpack_blaze_menu(): bool {
+		return false;
 	}
 
 	/**
-	 * Returns the full admin URL path for the Blaze Ads dashboard page.
+	 * Checks if the Jetpack top-level admin menu is registered.
 	 *
-	 * @return string E.g. 'admin.php?page=wp-blaze'.
+	 * @return bool True if the 'jetpack' top-level menu exists.
 	 */
-	public function get_admin_page_url_path(): string {
-		return 'admin.php?page=wp-blaze';
-	}
-
-	/**
-	 * Invalidates the jetpack-blaze active campaigns transient when the user
-	 * loads the Blaze Ads dashboard page. This ensures the menu position
-	 * updates on the next admin page load after a campaign is created.
-	 */
-	public function maybe_invalidate_campaigns_cache(): void {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['page'] ) && 'wp-blaze' === $_GET['page'] ) {
-			$site_id = Jetpack_Connection_Manager::get_site_id();
-			if ( is_numeric( $site_id ) ) {
-				delete_transient( 'jetpack_blaze_has_site_campaigns_' . $site_id );
+	private static function is_jetpack_parent_available(): bool {
+		global $menu;
+		foreach ( (array) $menu as $item ) {
+			if ( isset( $item[2] ) && 'jetpack' === $item[2] ) {
+				return true;
 			}
 		}
+		return false;
 	}
 
 	/**
-	 * Handles the redirection from the Jetpack Blaze dashboard URL to the new Blaze Ads dashboard
+	 * Adds Blaze entry point to the menu under the Marketing section.
+	 */
+	public function add_admin_menu(): void {
+		$menu_slug       = 'advertising';
+		$parent_slug     = $this->get_menu_parent();
+		$page_base       = 'tools.php' === $parent_slug ? 'tools.php' : 'admin.php';
+		$blaze_dashboard = new Jetpack_Blaze_Dashboard( $page_base, $menu_slug, 'woo-blaze' );
+
+		if ( 'tools.php' === $parent_slug ) {
+			// Fallback: no Jetpack, no WooCommerce — register under Tools.
+			$page_suffix = add_submenu_page(
+				'tools.php',
+				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
+				__( 'Blaze Ads', 'blaze-ads' ),
+				'manage_options',
+				$menu_slug,
+				array( $blaze_dashboard, 'render' ),
+				1
+			);
+		} else {
+			// Register under Jetpack or WooCommerce Marketing — both resolve at admin.php.
+			$page_suffix = add_submenu_page(
+				$parent_slug,
+				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
+				__( 'Blaze Ads', 'blaze-ads' ),
+				'manage_options',
+				$menu_slug,
+				array( $blaze_dashboard, 'render' ),
+				1
+			);
+		}
+		add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+	}
+
+	/**
+	 * Returns the parent menu slug for the Blaze Ads submenu.
+	 *
+	 * Priority: WooCommerce Marketing > Jetpack > Tools.
+	 *
+	 * @return string Parent menu slug.
+	 */
+	private function get_menu_parent(): string {
+		if ( $this->can_display_marketing_menu() ) {
+			return 'woocommerce-marketing';
+		}
+
+		if ( self::is_jetpack_parent_available() ) {
+			return 'jetpack';
+		}
+
+		return 'tools.php';
+	}
+
+	/**
+	 * Handles the redirection from the legacy wp-blaze slug to the current advertising slug.
 	 *
 	 * @return void
 	 */
@@ -102,10 +145,10 @@ class Blaze_Dashboard {
 		global $pagenow;
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['page'] ) && 'advertising' === $_GET['page']
+		if ( isset( $_GET['page'] ) && 'wp-blaze' === $_GET['page']
 			&& in_array( $pagenow, array( 'tools.php', 'admin.php' ), true )
 		) {
-			wp_safe_redirect( admin_url( '/' . $this->get_admin_page_url_path(), 'http' ), 302 );
+			wp_safe_redirect( admin_url( 'admin.php?page=advertising' ), 302 );
 			exit;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -132,7 +175,7 @@ class Blaze_Dashboard {
 		$setup_reason = $this->check_setup_plugin_status();
 
 		$data['is_blaze_plugin']       = true;
-		$data['dashboard_path_prefix'] = '/wp-blaze';
+		$data['dashboard_path_prefix'] = '/advertising';
 		$data['is_woo_store']          = Blaze_Dependency_Service::is_woo_core_active();
 		$data['need_setup']            = $setup_reason ?? false;
 
@@ -206,7 +249,7 @@ class Blaze_Dashboard {
 	 * @return string Jetpack connect url.
 	 */
 	public function get_connect_url( string $blazeads_connect_from = '1' ): string {
-		$admin_page = $this->get_admin_page_url_path();
+		$admin_page = 'admin.php?page=advertising';
 		$url        = add_query_arg(
 			array( 'blaze-ads-connect' => $blazeads_connect_from ),
 			admin_url( $admin_page )

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -13,12 +13,23 @@ use Automattic\Jetpack\Blaze as Jetpack_Blaze;
 use Automattic\Jetpack\Blaze\Dashboard as Jetpack_Blaze_Dashboard;
 use Automattic\Jetpack\Modules as Jetpack_Modules;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use BlazeAds\Exceptions\Base_Exception;
+use Jetpack_Options;
 
 /**
  * Its responsibility is to render the customized version of the Blaze Dashboard.
  */
 class Blaze_Dashboard {
 
+	/**
+	 * Transient key for caching the active campaigns check.
+	 */
+	const ACTIVE_CAMPAIGNS_TRANSIENT = 'blazeads_has_active_campaigns';
+
+	/**
+	 * TTL for the active campaigns transient, in seconds (1 hour).
+	 */
+	const ACTIVE_CAMPAIGNS_TRANSIENT_TTL = HOUR_IN_SECONDS;
 
 	/**
 	 * Initializes/configures the Jetpack Blaze module.
@@ -64,13 +75,102 @@ class Blaze_Dashboard {
 	}
 
 	/**
+	 * Determines whether the non-Woo menu should be promoted to a top-level menu page.
+	 *
+	 * The menu is promoted when the site is not a WooCommerce store and has active
+	 * Blaze campaigns. This makes the Blaze Ads entry more visible in the admin sidebar.
+	 *
+	 * @return bool True if the menu should be a top-level page.
+	 */
+	public function should_promote_to_top_level(): bool {
+		if ( $this->can_display_marketing_menu() ) {
+			return false;
+		}
+
+		return self::has_active_campaigns();
+	}
+
+	/**
+	 * Checks if the site has any active Blaze campaigns by calling the DSP API.
+	 *
+	 * Results are cached with a transient for 1 hour. This method is independent of
+	 * the WooCommerce MarketingCampaign infrastructure and returns a simple boolean.
+	 *
+	 * @return bool True if the site has at least one active campaign.
+	 */
+	public static function has_active_campaigns(): bool {
+		$cached = get_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT );
+		if ( false !== $cached ) {
+			return (bool) $cached;
+		}
+
+		$has_campaigns = false;
+
+		try {
+			$blog_id = Jetpack_Options::get_option( 'id' );
+			if ( empty( $blog_id ) ) {
+				set_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT, 0, self::ACTIVE_CAMPAIGNS_TRANSIENT_TTL );
+				return false;
+			}
+
+			$query_params = array(
+				'status' => 'active',
+			);
+
+			$path     = sprintf( 'v1/search/campaigns/site/%s', $blog_id );
+			$response = Blaze_Ads_Utils::call_dsp_server( $blog_id, $path, 'GET', $query_params );
+
+			if ( 200 === $response['status'] && isset( $response['body']['campaigns'] ) && ! empty( $response['body']['campaigns'] ) ) {
+				$has_campaigns = true;
+			}
+		} catch ( Base_Exception $e ) {
+			// On failure, cache as false so we don't keep retrying on every page load.
+			$has_campaigns = false;
+		}
+
+		set_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT, $has_campaigns ? 1 : 0, self::ACTIVE_CAMPAIGNS_TRANSIENT_TTL );
+
+		return $has_campaigns;
+	}
+
+	/**
+	 * Returns the admin page base for the Blaze Ads dashboard.
+	 *
+	 * For WooCommerce stores the dashboard lives under admin.php. For non-Woo sites
+	 * it is either admin.php (when promoted to top-level) or tools.php (submenu fallback).
+	 *
+	 * @return string The page base, e.g. 'admin.php' or 'tools.php'.
+	 */
+	public function get_admin_page_base(): string {
+		if ( $this->can_display_marketing_menu() ) {
+			return 'admin.php';
+		}
+
+		if ( $this->should_promote_to_top_level() ) {
+			return 'admin.php';
+		}
+
+		return 'tools.php';
+	}
+
+	/**
+	 * Returns the full admin URL path for the Blaze Ads dashboard page.
+	 *
+	 * @return string E.g. 'admin.php?page=wp-blaze' or 'tools.php?page=wp-blaze'.
+	 */
+	public function get_admin_page_url_path(): string {
+		return $this->get_admin_page_base() . '?page=wp-blaze';
+	}
+
+	/**
 	 * Adds Blaze entry point to the menu under the Marketing section.
 	 */
 	public function add_admin_menu(): void {
 		$menu_slug              = 'wp-blaze';
 		$display_marketing_menu = $this->can_display_marketing_menu();
+		$promote_to_top_level   = $this->should_promote_to_top_level();
 
-		$blaze_dashboard = new Jetpack_Blaze_Dashboard( $display_marketing_menu ? 'admin.php' : 'tools.php', $menu_slug, 'woo-blaze' );
+		$blaze_dashboard = new Jetpack_Blaze_Dashboard( $this->get_admin_page_base(), $menu_slug, 'woo-blaze' );
 
 		if ( $display_marketing_menu ) {
 			$page_suffix = add_submenu_page(
@@ -81,11 +181,21 @@ class Blaze_Dashboard {
 				$menu_slug,
 				array( $blaze_dashboard, 'render' )
 			);
+		} elseif ( $promote_to_top_level ) {
+			$page_suffix = add_menu_page(
+				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
+				__( 'Blaze Ads', 'blaze-ads' ),
+				'manage_options',
+				$menu_slug,
+				array( $blaze_dashboard, 'render' ),
+				'dashicons-megaphone',
+				30
+			);
 		} else {
 			$page_suffix = add_submenu_page(
 				'tools.php',
-				esc_attr__( 'Advertising', 'blaze-ads' ),
-				__( 'Advertising', 'blaze-ads' ),
+				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
+				__( 'Blaze Ads', 'blaze-ads' ),
 				'manage_options',
 				$menu_slug,
 				array( $blaze_dashboard, 'render' ),
@@ -206,7 +316,7 @@ class Blaze_Dashboard {
 	 * @return string Jetpack connect url.
 	 */
 	public function get_connect_url( string $blazeads_connect_from = '1' ): string {
-		$admin_page = Blaze_Dependency_Service::is_woo_core_active() ? 'admin.php?page=wp-blaze' : 'tools.php?page=wp-blaze';
+		$admin_page = $this->get_admin_page_url_path();
 		$url        = add_query_arg(
 			array( 'blaze-ads-connect' => $blazeads_connect_from ),
 			admin_url( $admin_page )

--- a/includes/class-blaze-dashboard.php
+++ b/includes/class-blaze-dashboard.php
@@ -10,11 +10,8 @@ namespace BlazeAds;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Blaze as Jetpack_Blaze;
-use Automattic\Jetpack\Blaze\Dashboard as Jetpack_Blaze_Dashboard;
 use Automattic\Jetpack\Modules as Jetpack_Modules;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
-use BlazeAds\Exceptions\Base_Exception;
-use Jetpack_Options;
 
 /**
  * Its responsibility is to render the customized version of the Blaze Dashboard.
@@ -22,26 +19,17 @@ use Jetpack_Options;
 class Blaze_Dashboard {
 
 	/**
-	 * Transient key for caching the active campaigns check.
-	 */
-	const ACTIVE_CAMPAIGNS_TRANSIENT = 'blazeads_has_active_campaigns';
-
-	/**
-	 * TTL for the active campaigns transient, in seconds (1 hour).
-	 */
-	const ACTIVE_CAMPAIGNS_TRANSIENT_TTL = HOUR_IN_SECONDS;
-
-	/**
 	 * Initializes/configures the Jetpack Blaze module.
 	 */
 	public function initialize(): void {
 		// Configures the additional information we need in the state.
 		add_filter( 'jetpack_blaze_dashboard_config_data', array( $this, 'blaze_ads_initial_config_data' ), 10, 1 );
-		// Allow disabling of the Jetpack Blaze menu for non-Woo sites, to avoid showing 2 advertising sub menus in the Tools menu.
-		add_filter( 'jetpack_blaze_enabled', array( $this, 'should_enable_jetpack_blaze_menu' ), 10, 1 );
 
-		// Add initial actions.
-		add_action( 'admin_menu', array( $this, 'add_admin_menu' ), 999 );
+		// Customize jetpack-blaze menu registration via filters (slug, CSS prefix).
+		add_filter( 'jetpack_blaze_menu_slug', array( $this, 'get_menu_slug' ) );
+		add_filter( 'jetpack_blaze_dashboard_css_prefix', array( $this, 'get_css_prefix' ) );
+
+		// Redirect legacy ?page=advertising URLs to ?page=wp-blaze.
 		add_action( 'admin_menu', array( $this, 'jetpack_dashboard_redirection' ), 999 );
 		add_action(
 			'admin_init',
@@ -49,7 +37,10 @@ class Blaze_Dashboard {
 			1000
 		); // Run this after dashboard redirect.
 
-		// We initialize the module ony if we are running standalone, or if Jetpack Blaze is enabled inside Jetpack plugin.
+		// Invalidate jetpack-blaze campaign cache on dashboard page load.
+		add_action( 'admin_init', array( $this, 'maybe_invalidate_campaigns_cache' ) );
+
+		// We initialize the module only if we are running standalone, or if Jetpack Blaze is enabled inside Jetpack plugin.
 		// We don't want to override the user's decision to disable Blaze. We have a specific page that shows how to re-enable it.
 		if ( $this->is_blaze_module_active() ) {
 			Jetpack_Blaze::init();
@@ -57,155 +48,49 @@ class Blaze_Dashboard {
 	}
 
 	/**
-	 * Checks if the Marketing Blaze submenu can be displayed on the site.
+	 * Returns the menu slug used by Blaze Ads.
 	 *
-	 * @return bool
+	 * Hooked to `jetpack_blaze_menu_slug` to override the default 'advertising'.
+	 *
+	 * @return string
 	 */
-	public function can_display_marketing_menu(): bool {
-		return Blaze_Dependency_Service::is_woo_core_active();
+	public function get_menu_slug(): string {
+		return 'wp-blaze';
 	}
 
 	/**
-	 * Checks if the Jetpack Blaze menu should be enabled.
+	 * Returns the CSS prefix for the Blaze Ads dashboard.
 	 *
-	 * @return bool
+	 * Hooked to `jetpack_blaze_dashboard_css_prefix` to override the default 'jp-blaze'.
+	 *
+	 * @return string
 	 */
-	public function should_enable_jetpack_blaze_menu(): bool {
-		return false;
-	}
-
-	/**
-	 * Determines whether the menu should be promoted to a top-level menu page.
-	 *
-	 * The menu is promoted when the site has active Blaze campaigns, regardless
-	 * of whether WooCommerce is active. This makes the Blaze Ads entry more
-	 * visible in the admin sidebar.
-	 *
-	 * @return bool True if the menu should be a top-level page.
-	 */
-	public function should_promote_to_top_level(): bool {
-		return self::has_active_campaigns();
-	}
-
-	/**
-	 * Checks if the site has any active Blaze campaigns by calling the DSP API.
-	 *
-	 * Results are cached with a transient for 1 hour. This method is independent of
-	 * the WooCommerce MarketingCampaign infrastructure and returns a simple boolean.
-	 *
-	 * @return bool True if the site has at least one active campaign.
-	 */
-	public static function has_active_campaigns(): bool {
-		$cached = get_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT );
-		if ( false !== $cached ) {
-			return (bool) $cached;
-		}
-
-		$has_campaigns = false;
-
-		try {
-			$blog_id = Jetpack_Options::get_option( 'id' );
-			if ( empty( $blog_id ) ) {
-				set_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT, 0, self::ACTIVE_CAMPAIGNS_TRANSIENT_TTL );
-				return false;
-			}
-
-			$path     = sprintf( 'v1/campaigns/site/%s/stats', $blog_id );
-			$response = Blaze_Ads_Utils::call_dsp_server( $blog_id, $path, 'GET' );
-
-			if ( 200 === $response['status'] && isset( $response['body']['total'] ) && ! empty( $response['body']['total'] ) ) {
-				$has_campaigns = true;
-			}
-		} catch ( Base_Exception $e ) {
-			// On failure, cache as false so we don't keep retrying on every page load.
-			$has_campaigns = false;
-		}
-
-		set_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT, $has_campaigns ? 1 : 0, self::ACTIVE_CAMPAIGNS_TRANSIENT_TTL );
-
-		return $has_campaigns;
-	}
-
-	/**
-	 * Returns the admin page base for the Blaze Ads dashboard.
-	 *
-	 * When promoted to top-level (active campaigns in any context) or displayed
-	 * under the WooCommerce Marketing submenu, the base is admin.php. Otherwise,
-	 * for non-Woo sites without active campaigns, it falls back to tools.php.
-	 *
-	 * @return string The page base, e.g. 'admin.php' or 'tools.php'.
-	 */
-	public function get_admin_page_base(): string {
-		if ( $this->should_promote_to_top_level() ) {
-			return 'admin.php';
-		}
-
-		if ( $this->can_display_marketing_menu() ) {
-			return 'admin.php';
-		}
-
-		return 'tools.php';
+	public function get_css_prefix(): string {
+		return 'woo-blaze';
 	}
 
 	/**
 	 * Returns the full admin URL path for the Blaze Ads dashboard page.
 	 *
-	 * @return string E.g. 'admin.php?page=wp-blaze' or 'tools.php?page=wp-blaze'.
+	 * @return string E.g. 'admin.php?page=wp-blaze'.
 	 */
 	public function get_admin_page_url_path(): string {
-		return $this->get_admin_page_base() . '?page=wp-blaze';
+		return 'admin.php?page=wp-blaze';
 	}
 
 	/**
-	 * Adds Blaze entry point to the menu under the Marketing section.
+	 * Invalidates the jetpack-blaze active campaigns transient when the user
+	 * loads the Blaze Ads dashboard page. This ensures the menu position
+	 * updates on the next admin page load after a campaign is created.
 	 */
-	public function add_admin_menu(): void {
-		$menu_slug            = 'wp-blaze';
-		$promote_to_top_level = $this->should_promote_to_top_level();
-
-		$blaze_dashboard = new Jetpack_Blaze_Dashboard( $this->get_admin_page_base(), $menu_slug, 'woo-blaze' );
-
-		if ( $promote_to_top_level ) {
-			$page_suffix = add_menu_page(
-				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
-				__( 'Blaze Ads', 'blaze-ads' ),
-				'manage_options',
-				$menu_slug,
-				array( $blaze_dashboard, 'render' ),
-				'dashicons-megaphone',
-				30
-			);
-		} elseif ( $this->can_display_marketing_menu() ) {
-			$page_suffix = add_submenu_page(
-				'woocommerce-marketing',
-				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
-				__( 'Blaze Ads', 'blaze-ads' ),
-				'manage_options',
-				$menu_slug,
-				array( $blaze_dashboard, 'render' )
-			);
-		} else {
-			$page_suffix = add_submenu_page(
-				'tools.php',
-				esc_attr__( 'Blaze Ads', 'blaze-ads' ),
-				__( 'Blaze Ads', 'blaze-ads' ),
-				'manage_options',
-				$menu_slug,
-				array( $blaze_dashboard, 'render' ),
-				1
-			);
+	public function maybe_invalidate_campaigns_cache(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && 'wp-blaze' === $_GET['page'] ) {
+			$site_id = Jetpack_Connection_Manager::get_site_id();
+			if ( is_numeric( $site_id ) ) {
+				delete_transient( 'jetpack_blaze_has_active_campaigns_' . $site_id );
+			}
 		}
-		add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
-		add_action( 'load-' . $page_suffix, array( $this, 'invalidate_campaigns_cache' ) );
-	}
-
-	/**
-	 * Invalidates the active campaigns transient when the user loads the
-	 * Blaze Ads dashboard page. This ensures the menu position updates on
-	 * the next admin page load after a campaign is created or finishes.
-	 */
-	public function invalidate_campaigns_cache(): void {
-		delete_transient( self::ACTIVE_CAMPAIGNS_TRANSIENT );
 	}
 
 	/**

--- a/includes/class-jetpack-connect-handler.php
+++ b/includes/class-jetpack-connect-handler.php
@@ -58,7 +58,7 @@ class Jetpack_Connect_Handler {
 	 * @return void
 	 */
 	private function redirect_to_onboarding_flow_page( string $source ) {
-		$admin_page   = Blaze_Dependency_Service::is_woo_core_active() ? 'admin.php?page=wp-blaze' : 'tools.php?page=wp-blaze';
+		$admin_page   = ( new Blaze_Dashboard() )->get_admin_page_url_path();
 		$redirect_url = add_query_arg(
 			array( 'source' => $source ),
 			admin_url( $admin_page )

--- a/includes/class-jetpack-connect-handler.php
+++ b/includes/class-jetpack-connect-handler.php
@@ -86,7 +86,8 @@ class Jetpack_Connect_Handler {
 			set_transient( self::ERROR_MESSAGE_TRANSIENT, $error_message, 30 );
 		}
 
-		wp_safe_redirect( admin_url( 'admin.php?page=wp-blaze' ) );
+		$admin_page = ( new Blaze_Dashboard() )->get_admin_page_url_path();
+		wp_safe_redirect( admin_url( $admin_page ) );
 		exit();
 	}
 

--- a/tests/php/blaze-dashboard-test.php
+++ b/tests/php/blaze-dashboard-test.php
@@ -264,4 +264,28 @@ class Blaze_Dashboard_Test extends BA_Unit_Test_Case {
 		$this->assertEquals( 'tools.php', $dashboard->get_admin_page_base() );
 	}
 
+	/**
+	 * Ensure the Jetpack Blaze menu is always disabled when the plugin is active.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::should_enable_jetpack_blaze_menu
+	 */
+	public function test_jetpack_blaze_menu_always_disabled() {
+		$dashboard = new Blaze_Dashboard();
+		$this->assertFalse( $dashboard->should_enable_jetpack_blaze_menu() );
+	}
+
+	/**
+	 * Ensure invalidate_campaigns_cache deletes the transient.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::invalidate_campaigns_cache
+	 */
+	public function test_invalidate_campaigns_cache_deletes_transient() {
+		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 1, HOUR_IN_SECONDS );
+
+		$dashboard = new Blaze_Dashboard();
+		$dashboard->invalidate_campaigns_cache();
+
+		$this->assertFalse( get_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT ) );
+	}
+
 }

--- a/tests/php/blaze-dashboard-test.php
+++ b/tests/php/blaze-dashboard-test.php
@@ -123,14 +123,36 @@ class Blaze_Dashboard_Test extends BA_Unit_Test_Case {
 	}
 
 	/**
-	 * Ensure that should_promote_to_top_level returns false for WooCommerce stores.
+	 * Ensure that WooCommerce stores with active campaigns promote to top-level.
 	 *
 	 * @covers BlazeAds\Blaze_Dashboard::should_promote_to_top_level
 	 */
-	public function test_should_not_promote_when_woo_active() {
+	public function test_should_promote_when_woo_active_with_campaigns() {
+		// Seed the transient with a "true" value to simulate active campaigns.
+		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 1, HOUR_IN_SECONDS );
+
 		// The test bootstrap loads WooCommerce, so can_display_marketing_menu() returns true.
 		$dashboard = new Blaze_Dashboard();
+		$this->assertTrue( $dashboard->should_promote_to_top_level() );
+
+		// Clean up.
+		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
+	}
+
+	/**
+	 * Ensure that WooCommerce stores without active campaigns do not promote to top-level.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::should_promote_to_top_level
+	 */
+	public function test_should_not_promote_when_woo_active_without_campaigns() {
+		// Seed the transient with a "false" value to simulate no active campaigns.
+		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 0, HOUR_IN_SECONDS );
+
+		$dashboard = new Blaze_Dashboard();
 		$this->assertFalse( $dashboard->should_promote_to_top_level() );
+
+		// Clean up.
+		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
 	}
 
 	/**
@@ -242,12 +264,4 @@ class Blaze_Dashboard_Test extends BA_Unit_Test_Case {
 		$this->assertEquals( 'tools.php', $dashboard->get_admin_page_base() );
 	}
 
-	private function mock_wp_remote_get( $response ) {
-		add_filter(
-			'pre_http_request',
-			function () use ( $response ) {
-				return $response;
-			}
-		);
-	}
 }

--- a/tests/php/blaze-dashboard-test.php
+++ b/tests/php/blaze-dashboard-test.php
@@ -55,6 +55,193 @@ class Blaze_Dashboard_Test extends BA_Unit_Test_Case {
 		$this->assertNotEmpty( $data['need_setup'] );
 	}
 
+	/**
+	 * Ensure non-WooCommerce menu uses "Blaze Ads" label (not "Advertising").
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::add_admin_menu
+	 */
+	public function test_non_woo_menu_uses_blaze_ads_label() {
+		// Mock a non-WooCommerce environment.
+		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
+			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
+			->getMock();
+
+		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
+		$dashboard->method( 'should_promote_to_top_level' )->willReturn( false );
+
+		$dashboard->add_admin_menu();
+
+		// Verify the submenu page was registered under tools.php.
+		$menu_url = menu_page_url( 'wp-blaze', false );
+		$this->assertNotEmpty( $menu_url );
+
+		// Check that the menu label is "Blaze Ads" by inspecting the global $submenu.
+		global $submenu;
+		$found_label = null;
+		if ( isset( $submenu['tools.php'] ) ) {
+			foreach ( $submenu['tools.php'] as $item ) {
+				if ( 'wp-blaze' === $item[2] ) {
+					$found_label = $item[0];
+					break;
+				}
+			}
+		}
+		$this->assertNotNull( $found_label, 'wp-blaze submenu should exist under tools.php' );
+		$this->assertEquals( 'Blaze Ads', $found_label );
+	}
+
+	/**
+	 * Ensure the menu is promoted to top-level when active campaigns exist.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::add_admin_menu
+	 */
+	public function test_top_level_menu_when_active_campaigns() {
+		// Mock a non-WooCommerce environment with active campaigns.
+		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
+			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
+			->getMock();
+
+		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
+		$dashboard->method( 'should_promote_to_top_level' )->willReturn( true );
+
+		$dashboard->add_admin_menu();
+
+		// A top-level page registers under $menu, not $submenu.
+		global $menu;
+		$found = false;
+		if ( is_array( $menu ) ) {
+			foreach ( $menu as $item ) {
+				if ( isset( $item[2] ) && 'wp-blaze' === $item[2] ) {
+					$found = true;
+					$this->assertEquals( 'Blaze Ads', $item[0] );
+					$this->assertEquals( 'dashicons-megaphone', $item[6] );
+					break;
+				}
+			}
+		}
+		$this->assertTrue( $found, 'wp-blaze should be registered as a top-level menu page' );
+	}
+
+	/**
+	 * Ensure that should_promote_to_top_level returns false for WooCommerce stores.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::should_promote_to_top_level
+	 */
+	public function test_should_not_promote_when_woo_active() {
+		// The test bootstrap loads WooCommerce, so can_display_marketing_menu() returns true.
+		$dashboard = new Blaze_Dashboard();
+		$this->assertFalse( $dashboard->should_promote_to_top_level() );
+	}
+
+	/**
+	 * Ensure has_active_campaigns returns false when there is no blog ID.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::has_active_campaigns
+	 */
+	public function test_has_active_campaigns_returns_false_without_blog_id() {
+		// Clear any cached transient.
+		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
+
+		$result = Blaze_Dashboard::has_active_campaigns();
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Ensure has_active_campaigns uses cached transient value.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::has_active_campaigns
+	 */
+	public function test_has_active_campaigns_uses_transient_cache() {
+		// Seed the transient with a "true" value.
+		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 1, HOUR_IN_SECONDS );
+		$this->assertTrue( Blaze_Dashboard::has_active_campaigns() );
+
+		// Seed with a "false" value.
+		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 0, HOUR_IN_SECONDS );
+		$this->assertFalse( Blaze_Dashboard::has_active_campaigns() );
+
+		// Clean up.
+		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
+	}
+
+	/**
+	 * Ensure non-Woo connect URL uses admin.php when promoted to top-level.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_connect_url
+	 */
+	public function test_connect_url_uses_admin_php_when_top_level() {
+		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
+			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
+			->getMock();
+
+		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
+		$dashboard->method( 'should_promote_to_top_level' )->willReturn( true );
+
+		$url = $dashboard->get_connect_url();
+		$this->assertStringContainsString( 'admin.php?page=wp-blaze', $url );
+		$this->assertStringNotContainsString( 'tools.php', $url );
+	}
+
+	/**
+	 * Ensure non-Woo connect URL uses tools.php when not promoted.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_connect_url
+	 */
+	public function test_connect_url_uses_tools_php_when_submenu() {
+		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
+			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
+			->getMock();
+
+		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
+		$dashboard->method( 'should_promote_to_top_level' )->willReturn( false );
+
+		$url = $dashboard->get_connect_url();
+		$this->assertStringContainsString( 'tools.php?page=wp-blaze', $url );
+	}
+
+	/**
+	 * Ensure get_admin_page_base returns correct values for each scenario.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_base
+	 */
+	public function test_get_admin_page_base_woo() {
+		// Test bootstrap loads WooCommerce, so this should be admin.php.
+		$dashboard = new Blaze_Dashboard();
+		$this->assertEquals( 'admin.php', $dashboard->get_admin_page_base() );
+	}
+
+	/**
+	 * Ensure get_admin_page_base returns admin.php when promoted to top-level.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_base
+	 */
+	public function test_get_admin_page_base_top_level() {
+		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
+			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
+			->getMock();
+
+		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
+		$dashboard->method( 'should_promote_to_top_level' )->willReturn( true );
+
+		$this->assertEquals( 'admin.php', $dashboard->get_admin_page_base() );
+	}
+
+	/**
+	 * Ensure get_admin_page_base returns tools.php for non-Woo submenu fallback.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_base
+	 */
+	public function test_get_admin_page_base_tools_submenu() {
+		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
+			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
+			->getMock();
+
+		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
+		$dashboard->method( 'should_promote_to_top_level' )->willReturn( false );
+
+		$this->assertEquals( 'tools.php', $dashboard->get_admin_page_base() );
+	}
+
 	private function mock_wp_remote_get( $response ) {
 		add_filter(
 			'pre_http_request',

--- a/tests/php/blaze-dashboard-test.php
+++ b/tests/php/blaze-dashboard-test.php
@@ -30,16 +30,57 @@ class Blaze_Dashboard_Test extends BA_Unit_Test_Case {
 	}
 
 	/**
-	 * Ensure the new admin menu is added in the correct section.
+	 * Ensure the menu slug filter is registered on initialize.
 	 *
-	 * @covers BlazeAds\Blaze_Dashboard::add_admin_menu
+	 * @covers BlazeAds\Blaze_Dashboard::initialize
 	 */
-	public function test_it_adds_admin_menu_correctly() {
-		( new Blaze_Dashboard() )->add_admin_menu();
+	public function test_initialize_registers_menu_slug_filter() {
+		$dashboard = new Blaze_Dashboard();
+		$dashboard->initialize();
 
-		$menu_url = menu_page_url( 'wp-blaze' );
-		$this->assertNotEmpty( $menu_url );
-		$this->assertMatchesRegularExpression( '/woocommerce-marketing/', $menu_url );
+		$this->assertNotFalse( has_filter( 'jetpack_blaze_menu_slug', array( $dashboard, 'get_menu_slug' ) ) );
+	}
+
+	/**
+	 * Ensure the CSS prefix filter is registered on initialize.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::initialize
+	 */
+	public function test_initialize_registers_css_prefix_filter() {
+		$dashboard = new Blaze_Dashboard();
+		$dashboard->initialize();
+
+		$this->assertNotFalse( has_filter( 'jetpack_blaze_dashboard_css_prefix', array( $dashboard, 'get_css_prefix' ) ) );
+	}
+
+	/**
+	 * Ensure get_menu_slug returns 'wp-blaze'.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_menu_slug
+	 */
+	public function test_get_menu_slug() {
+		$dashboard = new Blaze_Dashboard();
+		$this->assertEquals( 'wp-blaze', $dashboard->get_menu_slug() );
+	}
+
+	/**
+	 * Ensure get_css_prefix returns 'woo-blaze'.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_css_prefix
+	 */
+	public function test_get_css_prefix() {
+		$dashboard = new Blaze_Dashboard();
+		$this->assertEquals( 'woo-blaze', $dashboard->get_css_prefix() );
+	}
+
+	/**
+	 * Ensure get_admin_page_url_path returns the correct path.
+	 *
+	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_url_path
+	 */
+	public function test_get_admin_page_url_path() {
+		$dashboard = new Blaze_Dashboard();
+		$this->assertEquals( 'admin.php?page=wp-blaze', $dashboard->get_admin_page_url_path() );
 	}
 
 	/**
@@ -56,236 +97,13 @@ class Blaze_Dashboard_Test extends BA_Unit_Test_Case {
 	}
 
 	/**
-	 * Ensure non-WooCommerce menu uses "Blaze Ads" label (not "Advertising").
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::add_admin_menu
-	 */
-	public function test_non_woo_menu_uses_blaze_ads_label() {
-		// Mock a non-WooCommerce environment.
-		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
-			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
-			->getMock();
-
-		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
-		$dashboard->method( 'should_promote_to_top_level' )->willReturn( false );
-
-		$dashboard->add_admin_menu();
-
-		// Verify the submenu page was registered under tools.php.
-		$menu_url = menu_page_url( 'wp-blaze', false );
-		$this->assertNotEmpty( $menu_url );
-
-		// Check that the menu label is "Blaze Ads" by inspecting the global $submenu.
-		global $submenu;
-		$found_label = null;
-		if ( isset( $submenu['tools.php'] ) ) {
-			foreach ( $submenu['tools.php'] as $item ) {
-				if ( 'wp-blaze' === $item[2] ) {
-					$found_label = $item[0];
-					break;
-				}
-			}
-		}
-		$this->assertNotNull( $found_label, 'wp-blaze submenu should exist under tools.php' );
-		$this->assertEquals( 'Blaze Ads', $found_label );
-	}
-
-	/**
-	 * Ensure the menu is promoted to top-level when active campaigns exist.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::add_admin_menu
-	 */
-	public function test_top_level_menu_when_active_campaigns() {
-		// Mock a non-WooCommerce environment with active campaigns.
-		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
-			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
-			->getMock();
-
-		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
-		$dashboard->method( 'should_promote_to_top_level' )->willReturn( true );
-
-		$dashboard->add_admin_menu();
-
-		// A top-level page registers under $menu, not $submenu.
-		global $menu;
-		$found = false;
-		if ( is_array( $menu ) ) {
-			foreach ( $menu as $item ) {
-				if ( isset( $item[2] ) && 'wp-blaze' === $item[2] ) {
-					$found = true;
-					$this->assertEquals( 'Blaze Ads', $item[0] );
-					$this->assertEquals( 'dashicons-megaphone', $item[6] );
-					break;
-				}
-			}
-		}
-		$this->assertTrue( $found, 'wp-blaze should be registered as a top-level menu page' );
-	}
-
-	/**
-	 * Ensure that WooCommerce stores with active campaigns promote to top-level.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::should_promote_to_top_level
-	 */
-	public function test_should_promote_when_woo_active_with_campaigns() {
-		// Seed the transient with a "true" value to simulate active campaigns.
-		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 1, HOUR_IN_SECONDS );
-
-		// The test bootstrap loads WooCommerce, so can_display_marketing_menu() returns true.
-		$dashboard = new Blaze_Dashboard();
-		$this->assertTrue( $dashboard->should_promote_to_top_level() );
-
-		// Clean up.
-		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
-	}
-
-	/**
-	 * Ensure that WooCommerce stores without active campaigns do not promote to top-level.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::should_promote_to_top_level
-	 */
-	public function test_should_not_promote_when_woo_active_without_campaigns() {
-		// Seed the transient with a "false" value to simulate no active campaigns.
-		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 0, HOUR_IN_SECONDS );
-
-		$dashboard = new Blaze_Dashboard();
-		$this->assertFalse( $dashboard->should_promote_to_top_level() );
-
-		// Clean up.
-		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
-	}
-
-	/**
-	 * Ensure has_active_campaigns returns false when there is no blog ID.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::has_active_campaigns
-	 */
-	public function test_has_active_campaigns_returns_false_without_blog_id() {
-		// Clear any cached transient.
-		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
-
-		$result = Blaze_Dashboard::has_active_campaigns();
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Ensure has_active_campaigns uses cached transient value.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::has_active_campaigns
-	 */
-	public function test_has_active_campaigns_uses_transient_cache() {
-		// Seed the transient with a "true" value.
-		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 1, HOUR_IN_SECONDS );
-		$this->assertTrue( Blaze_Dashboard::has_active_campaigns() );
-
-		// Seed with a "false" value.
-		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 0, HOUR_IN_SECONDS );
-		$this->assertFalse( Blaze_Dashboard::has_active_campaigns() );
-
-		// Clean up.
-		delete_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT );
-	}
-
-	/**
-	 * Ensure non-Woo connect URL uses admin.php when promoted to top-level.
+	 * Ensure connect URL uses admin.php with wp-blaze slug.
 	 *
 	 * @covers BlazeAds\Blaze_Dashboard::get_connect_url
 	 */
-	public function test_connect_url_uses_admin_php_when_top_level() {
-		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
-			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
-			->getMock();
-
-		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
-		$dashboard->method( 'should_promote_to_top_level' )->willReturn( true );
-
-		$url = $dashboard->get_connect_url();
+	public function test_connect_url_uses_admin_php() {
+		$dashboard = new Blaze_Dashboard();
+		$url       = $dashboard->get_connect_url();
 		$this->assertStringContainsString( 'admin.php?page=wp-blaze', $url );
-		$this->assertStringNotContainsString( 'tools.php', $url );
 	}
-
-	/**
-	 * Ensure non-Woo connect URL uses tools.php when not promoted.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::get_connect_url
-	 */
-	public function test_connect_url_uses_tools_php_when_submenu() {
-		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
-			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
-			->getMock();
-
-		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
-		$dashboard->method( 'should_promote_to_top_level' )->willReturn( false );
-
-		$url = $dashboard->get_connect_url();
-		$this->assertStringContainsString( 'tools.php?page=wp-blaze', $url );
-	}
-
-	/**
-	 * Ensure get_admin_page_base returns correct values for each scenario.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_base
-	 */
-	public function test_get_admin_page_base_woo() {
-		// Test bootstrap loads WooCommerce, so this should be admin.php.
-		$dashboard = new Blaze_Dashboard();
-		$this->assertEquals( 'admin.php', $dashboard->get_admin_page_base() );
-	}
-
-	/**
-	 * Ensure get_admin_page_base returns admin.php when promoted to top-level.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_base
-	 */
-	public function test_get_admin_page_base_top_level() {
-		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
-			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
-			->getMock();
-
-		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
-		$dashboard->method( 'should_promote_to_top_level' )->willReturn( true );
-
-		$this->assertEquals( 'admin.php', $dashboard->get_admin_page_base() );
-	}
-
-	/**
-	 * Ensure get_admin_page_base returns tools.php for non-Woo submenu fallback.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::get_admin_page_base
-	 */
-	public function test_get_admin_page_base_tools_submenu() {
-		$dashboard = $this->getMockBuilder( Blaze_Dashboard::class )
-			->onlyMethods( array( 'can_display_marketing_menu', 'should_promote_to_top_level' ) )
-			->getMock();
-
-		$dashboard->method( 'can_display_marketing_menu' )->willReturn( false );
-		$dashboard->method( 'should_promote_to_top_level' )->willReturn( false );
-
-		$this->assertEquals( 'tools.php', $dashboard->get_admin_page_base() );
-	}
-
-	/**
-	 * Ensure the Jetpack Blaze menu is always disabled when the plugin is active.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::should_enable_jetpack_blaze_menu
-	 */
-	public function test_jetpack_blaze_menu_always_disabled() {
-		$dashboard = new Blaze_Dashboard();
-		$this->assertFalse( $dashboard->should_enable_jetpack_blaze_menu() );
-	}
-
-	/**
-	 * Ensure invalidate_campaigns_cache deletes the transient.
-	 *
-	 * @covers BlazeAds\Blaze_Dashboard::invalidate_campaigns_cache
-	 */
-	public function test_invalidate_campaigns_cache_deletes_transient() {
-		set_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT, 1, HOUR_IN_SECONDS );
-
-		$dashboard = new Blaze_Dashboard();
-		$dashboard->invalidate_campaigns_cache();
-
-		$this->assertFalse( get_transient( Blaze_Dashboard::ACTIVE_CAMPAIGNS_TRANSIENT ) );
-	}
-
 }


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/ADS-796

## Summary

Renames the non-WooCommerce "Advertising" menu label to "Blaze Ads" and adds campaign-based top-level promotion for both WooCommerce and non-WooCommerce installations.

### Changes:
* Rename non-Woo labels from "Advertising" to "Blaze Ads" in `class-blaze-dashboard.php`
* Add `has_active_campaigns()` static method: Woo-independent DSP helper with 1-hour transient cache
* Add `should_promote_to_top_level()`: promotes to top-level `add_menu_page()` when active campaigns exist (all contexts, including WooCommerce)
* Add `get_admin_page_base()` and `get_admin_page_url_path()` helpers for dynamic URL generation
* Update `add_admin_menu()`: top-level check first, then Woo submenu, then tools.php fallback
* Update connect/return URLs (`get_connect_url()`, `redirect_to_onboarding_flow_page()`, `redirect_to_connect_home_page()`) to use dynamic paths
* Update IDC config `admin_page` to use dynamic path
* Update existing `advertising` -> `wp-blaze` redirect to use dynamic URL

### Tests added:
* Non-Woo menu label verification
* Top-level promotion for Woo and non-Woo contexts
* Campaign detection with transient caching
* Connect URL generation for both top-level and submenu states
* Admin page base detection

## Testing instructions

### Non-WooCommerce site:
1. Install plugin on a site without WooCommerce
2. Verify "Blaze Ads" appears under Tools menu (no campaigns) or as top-level (with campaigns)
3. Navigate to `tools.php?page=advertising` and verify redirect works

### WooCommerce site:
1. Install plugin on a WooCommerce site
2. Verify "Blaze Ads" appears under Marketing menu (no campaigns) or as top-level (with campaigns)
3. Complete Jetpack connection flow and verify return URLs are correct

### Campaign promotion:
1. On a site with active campaigns: verify top-level "Blaze Ads" with megaphone icon
2. Flush transient and verify demotion when no campaigns