### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-php/action.yml
+++ b/.github/actions/setup-php/action.yml
@@ -12,7 +12,7 @@ runs:
         echo "MIN_PHP_VERSION=$MIN_PHP_VERSION" >> $GITHUB_OUTPUT
 
     - name: "Setup PHP"
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
       with:
         php-version: ${{ steps.get_min_php_version.outputs.MIN_PHP_VERSION }}
         tools: composer

--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: "Set up pnpm"
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       if: ${{ inputs.setup-node-pnpm == 'true' }}
       with:
         version: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    # "/" covers .github/workflows + root action.yml only; the glob adds the
-    # nested composite actions (.github/actions/*/action.yml) pinned here.
+    # Scan composite actions too — their SHA-pinned `uses:` refs need update
+    # PRs just like the workflow files do ('**' covers nested action dirs).
     directories:
       - "/"
-      - "/.github/actions/*"
+      - "/.github/actions/**"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # "/" covers .github/workflows + root action.yml only; the glob adds the
+    # nested composite actions (.github/actions/*/action.yml) pinned here.
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/changelog/mahangu-devprod-1072-pin-actions-shas
+++ b/changelog/mahangu-devprod-1072-pin-actions-shas
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Pin third-party GitHub Actions to commit SHAs and add Dependabot coverage for workflows and composite actions. No runtime change.


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs, and makes Dependabot keep them fresh — in workflows **and** composite actions.

Tracking: DEVPROD-1072

## What's in this PR
- **Third-party pins (2):** `shivammathur/setup-php`, `pnpm/action-setup` — both live in composite actions (`.github/actions/*/action.yml`).
- **Dependabot coverage fix (per review 🙏):** the `github-actions` entry now uses `directories: ["/", "/.github/actions/*"]` — `directory: "/"` alone only scans `.github/workflows/` + a root `action.yml`, so the composite-action pins would never have received update PRs.
- Changelog entry added (`changelog/mahangu-devprod-1072-pin-actions-shas`).

First-party (GitHub-owned) refs such as `actions/setup-node@v4` are intentionally untouched — they're tracked separately and will be pinned in the first-party pass.

## Testing
- **CI green = behaviour unchanged**: each SHA is the exact commit the previous tag pointed to, so jobs resolve and run identically.
- Verify either pin by hand — resolve the tag and compare with the SHA in the file:

```bash
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'   # expect 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/pnpm/action-setup/commits/v3.0.0 --jq '.sha'        # expect a3252b78c470c02df07e9d59298aecedc3ccdd6d
```
- Dependabot config sanity: `.github/dependabot.yml` validates (schema v2; `directories` is supported and glob-capable per the Dependabot options reference).
